### PR TITLE
Issv3: new api to modify custom channels in the peripheral

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -1343,23 +1343,6 @@ public class ChannelFactory extends HibernateFactory {
     }
 
     /**
-     * Find {@link ContentSource} with source url containing urlPart.
-     * Uses SQL wildcard paramter '%'. When urlPart does contain a wildcard parameter, it is passed directly to
-     * the query. If not, a wildcard is added and the begining and the end.
-     * @param urlPart part of the url
-     * @return list of found {@link ContentSource}
-     */
-    public static List<ContentSource> findContentSourceLikeUrl(String urlPart) {
-        String urllike = urlPart;
-        if (!urlPart.contains("%")) {
-            urllike = java.lang.String.format("%%%s%%", urlPart);
-        }
-        return getSession().createNamedQuery("ContentSource.findLikeUrl", ContentSource.class)
-                .setParameter("urllike", urllike)
-                .list();
-    }
-
-    /**
      * Find a {@link ChannelProduct} for given name and version.
      * @param product the product
      * @param version the version

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2009--2017 Red Hat, Inc.
- * Copyright (c) 2011--2021 SUSE LLC
+ * Copyright (c) 2011--2025 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -15,6 +15,7 @@
  */
 package com.redhat.rhn.domain.channel;
 
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.CallableMode;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.db.datasource.ModeFactory;
@@ -24,13 +25,25 @@ import com.redhat.rhn.common.db.datasource.WriteMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.common.ChecksumType;
 import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.org.OrgFactory;
+import com.redhat.rhn.domain.product.ChannelTemplate;
+import com.redhat.rhn.domain.product.SUSEProductFactory;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.scc.SCCRepository;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.InvalidChannelLabelException;
 import com.redhat.rhn.manager.appstreams.AppStreamsManager;
+import com.redhat.rhn.manager.content.ContentSyncManager;
+import com.redhat.rhn.manager.content.MgrSyncUtils;
 import com.redhat.rhn.manager.ssm.SsmChannelDto;
 
+import com.suse.manager.model.hub.CustomChannelInfoJson;
+import com.suse.manager.model.hub.HubFactory;
+import com.suse.scc.SCCEndpoints;
+import com.suse.scc.model.SCCRepositoryJson;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hibernate.Session;
@@ -43,6 +56,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -707,9 +721,8 @@ public class ChannelFactory extends HibernateFactory {
      * @return List of modular channels
      */
     public static List<Channel> listModularChannels(User user) {
-        List<Channel> channels = singleton.listObjectsByNamedQuery("Channel.findModularChannels",
-                Map.of("org_id", user.getOrg().getId()));
-        return channels;
+        return singleton.listObjectsByNamedQuery("Channel.findModularChannels",
+                Map.of(ORG_ID, user.getOrg().getId()));
     }
 
     /**
@@ -1452,6 +1465,272 @@ public class ChannelFactory extends HibernateFactory {
                 to.setModules(modules);
             }
             to.getModules().setRelativeFilename(from.getModules().getRelativeFilename());
+        }
+    }
+
+    /**
+     * Converts a custom channel to a custom channel info structure
+     *
+     * @param customChannel              the custom channel to be converted
+     * @param peripheralOrgId            the peripheral org id this channel will be assigned to in the peripheral
+     * @param forcedOriginalChannelLabel an optional string setting the original of a cloned channel,
+     *                                   instead of the pristine one
+     * @return CustomChannelInfoJson the converted info of the custom channel
+     */
+    public static CustomChannelInfoJson toCustomChannelInfo(Channel customChannel, long peripheralOrgId,
+                                                            Optional<String> forcedOriginalChannelLabel) {
+
+        if (!customChannel.isCustom()) {
+            throw new IllegalArgumentException("Channel [" + customChannel.getLabel() + "] is not custom");
+        }
+
+        CustomChannelInfoJson customChannelInfo = new CustomChannelInfoJson(customChannel.getLabel());
+
+        customChannelInfo.setPeripheralOrgId(peripheralOrgId);
+
+        String parentChannelLabel = (null == customChannel.getParentChannel()) ? null :
+                customChannel.getParentChannel().getLabel();
+        customChannelInfo.setParentChannelLabel(parentChannelLabel);
+
+        String channelArchLabel = (null == customChannel.getChannelArch()) ? null :
+                customChannel.getChannelArch().getLabel();
+        customChannelInfo.setChannelArchLabel(channelArchLabel);
+
+        customChannelInfo.setBaseDir(customChannel.getBaseDir());
+        customChannelInfo.setName(customChannel.getName());
+        customChannelInfo.setSummary(customChannel.getSummary());
+        customChannelInfo.setDescription(customChannel.getDescription());
+
+        String productNameLabel = (null == customChannel.getProductName()) ? null :
+                customChannel.getProductName().getLabel();
+        customChannelInfo.setProductNameLabel(productNameLabel);
+
+        customChannelInfo.setGpgCheck(customChannel.isGPGCheck());
+        customChannelInfo.setGpgKeyUrl(customChannel.getGPGKeyUrl());
+        customChannelInfo.setGpgKeyId(customChannel.getGPGKeyId());
+        customChannelInfo.setGpgKeyFp(customChannel.getGPGKeyFp());
+
+        customChannelInfo.setEndOfLifeDate(customChannel.getEndOfLife());
+        customChannelInfo.setChecksumTypeLabel(customChannel.getChecksumTypeLabel());
+
+        String channelProductProduct = (null == customChannel.getProduct()) ? null :
+                customChannel.getProduct().getProduct();
+        customChannelInfo.setChannelProductProduct(channelProductProduct);
+        String channelProductVersion = (null == customChannel.getProduct()) ? null :
+                customChannel.getProduct().getVersion();
+        customChannelInfo.setChannelProductVersion(channelProductVersion);
+
+        customChannelInfo.setChannelAccess(customChannel.getAccess());
+        customChannelInfo.setMaintainerName(customChannel.getMaintainerName());
+        customChannelInfo.setMaintainerEmail(customChannel.getMaintainerEmail());
+        customChannelInfo.setMaintainerPhone(customChannel.getMaintainerPhone());
+        customChannelInfo.setSupportPolicy(customChannel.getSupportPolicy());
+        customChannelInfo.setUpdateTag(customChannel.getUpdateTag());
+        customChannelInfo.setInstallerUpdates(customChannel.isInstallerUpdates());
+
+        Optional<ClonedChannel> clonedChannel = customChannel.asCloned();
+        if (clonedChannel.isPresent()) {
+            if (forcedOriginalChannelLabel.isPresent()) {
+                customChannelInfo.setOriginalChannelLabel(forcedOriginalChannelLabel.get());
+            }
+            else {
+                customChannelInfo.setOriginalChannelLabel(clonedChannel.get().getOriginal().getLabel());
+            }
+        }
+        else {
+            customChannelInfo.setOriginalChannelLabel(null);
+        }
+
+        // obtain repository info
+        String hostname = ConfigDefaults.get().getJavaHostname();
+        String customChannelLabel = customChannel.getLabel();
+
+        Optional<String> tokenString = SCCEndpoints.buildHubRepositoryToken(customChannelLabel);
+        if (tokenString.isPresent()) {
+            SCCRepositoryJson repositoryInfo = SCCEndpoints.buildCustomRepoJson(customChannelLabel, hostname,
+                    tokenString.get());
+            customChannelInfo.setRepositoryInfo(repositoryInfo);
+        }
+
+        return customChannelInfo;
+    }
+
+    /**
+     * Converts a custom channel info structure to a custom channel
+     *
+     * @param customChannelInfo the custom channel info to be converted
+     * @return customChannel the converted custom channel
+     */
+    public static Channel toCustomChannel(CustomChannelInfoJson customChannelInfo) {
+        Org org = OrgFactory.lookupById(customChannelInfo.getPeripheralOrgId());
+        Channel parentChannel = ChannelFactory.lookupByLabel(customChannelInfo.getParentChannelLabel());
+        ChannelArch channelArch = ChannelFactory.findArchByLabel(customChannelInfo.getChannelArchLabel());
+        ChecksumType checksumType = ChannelFactory.findChecksumTypeByLabel(customChannelInfo.getChecksumTypeLabel());
+
+        Channel customChannel = new Channel();
+        if (StringUtils.isNotEmpty(customChannelInfo.getOriginalChannelLabel())) {
+            Channel originalChannel = ChannelFactory.lookupByLabel(customChannelInfo.getOriginalChannelLabel());
+
+            ClonedChannel temp = new ClonedChannel();
+            temp.setOriginal(originalChannel);
+            customChannel = temp;
+        }
+
+        customChannel.setOrg(org);
+        customChannel.setParentChannel(parentChannel);
+        customChannel.setChannelArch(channelArch);
+
+        customChannel.setLabel(customChannelInfo.getLabel());
+        customChannel.setBaseDir(customChannelInfo.getBaseDir());
+        customChannel.setName(customChannelInfo.getName());
+        customChannel.setSummary(customChannelInfo.getSummary());
+        customChannel.setDescription(customChannelInfo.getDescription());
+
+        customChannel.setProductName(MgrSyncUtils.findOrCreateProductName(customChannelInfo.getProductNameLabel()));
+
+        customChannel.setGPGCheck(customChannelInfo.isGpgCheck());
+        customChannel.setGPGKeyUrl(customChannelInfo.getGpgKeyUrl());
+        customChannel.setGPGKeyId(customChannelInfo.getGpgKeyId());
+        customChannel.setGPGKeyFp(customChannelInfo.getGpgKeyFp());
+
+        customChannel.setEndOfLife(customChannelInfo.getEndOfLifeDate());
+        customChannel.setChecksumType(checksumType);
+
+        customChannel.setProduct(MgrSyncUtils.findOrCreateChannelProduct(
+                customChannelInfo.getChannelProductProduct(), customChannelInfo.getChannelProductVersion()));
+
+        customChannel.setAccess(customChannelInfo.getChannelAccess());
+        customChannel.setMaintainerName(customChannelInfo.getMaintainerName());
+        customChannel.setMaintainerEmail(customChannelInfo.getMaintainerEmail());
+        customChannel.setMaintainerPhone(customChannelInfo.getMaintainerPhone());
+        customChannel.setSupportPolicy(customChannelInfo.getSupportPolicy());
+        customChannel.setUpdateTag(customChannelInfo.getUpdateTag());
+        customChannel.setInstallerUpdates(customChannelInfo.isInstallerUpdates());
+
+        // rebuild repository
+        ContentSyncManager csm = new ContentSyncManager();
+        HubFactory hubFactory = new HubFactory();
+        csm.refreshCustomRepo(List.of(customChannelInfo.getRepositoryInfo()), hubFactory.lookupIssHub().orElse(null));
+
+        return customChannel;
+    }
+
+    /**
+     * Ensures that the vendor channels json info structure is valid, as well as all consequent data
+     *
+     * @param vendorChannelLabelList list of vendor channel labels to be checked
+     * @throws IllegalArgumentException if something is wrong
+     */
+    public static void ensureValidVendorChannels(List<String> vendorChannelLabelList) {
+        for (String vendorChannelLabel : vendorChannelLabelList) {
+            Optional<ChannelTemplate> vendorChannelTemplate = SUSEProductFactory
+                    .lookupByChannelLabelFirst(vendorChannelLabel);
+
+            if (vendorChannelTemplate.isEmpty()) {
+                throw new InvalidChannelLabelException(vendorChannelLabel,
+                        InvalidChannelLabelException.Reason.IS_MISSING,
+                        "Invalid data: vendor channel label not found", vendorChannelLabel);
+            }
+        }
+    }
+
+    /**
+     * Ensures that the custom channels json info structure is valid, as well as all consequent data
+     *
+     * @param customChannelInfoJsonList list of custom channel info structures to be checked
+     * @throws IllegalArgumentException if something is wrong
+     */
+    public static void ensureValidCustomChannels(List<CustomChannelInfoJson> customChannelInfoJsonList) {
+        for (CustomChannelInfoJson customChannelInfo : customChannelInfoJsonList) {
+
+            if (ChannelFactory.doesChannelLabelExist(customChannelInfo.getLabel())) {
+                throw new IllegalArgumentException("Channel already found with the same label " +
+                        "for custom channel [" + customChannelInfo.getLabel() + "]");
+            }
+
+            ensureValidOrgIds(customChannelInfoJsonList);
+
+            ensureExistingOrAboutToCreate(customChannelInfoJsonList, false, "channel arch",
+                    CustomChannelInfoJson::getChannelArchLabel, ChannelFactory::findArchByLabel, null);
+
+            ensureExistingOrAboutToCreate(customChannelInfoJsonList, false, "checksum type",
+                    CustomChannelInfoJson::getChecksumTypeLabel, ChannelFactory::findChecksumTypeByLabel, null);
+
+            ensureExistingOrAboutToCreate(customChannelInfoJsonList, true, "parent channel",
+                    CustomChannelInfoJson::getParentChannelLabel, ChannelFactory::lookupByLabel,
+                    CustomChannelInfoJson::getLabel);
+
+            ensureExistingOrAboutToCreate(customChannelInfoJsonList, true, "original channel",
+                    CustomChannelInfoJson::getOriginalChannelLabel, ChannelFactory::lookupByLabel,
+                    CustomChannelInfoJson::getLabel);
+        }
+    }
+
+    @FunctionalInterface
+    private interface SearchLabelMethod {
+        String getSearchLabel(CustomChannelInfoJson arg);
+    }
+
+    @FunctionalInterface
+    private interface LookupLabelMethod {
+        Object lookupWithLabel(String label);
+    }
+
+    @FunctionalInterface
+    private interface AccumulateFollowingMethod {
+        String accumulateFollowing(CustomChannelInfoJson arg);
+    }
+
+    private static void ensureExistingOrAboutToCreate(List<CustomChannelInfoJson> customChannelInfoJsonList,
+                                                      boolean emptyIsAllowed, String informationTypeString,
+                                                      SearchLabelMethod searchLabelMethod,
+                                                      LookupLabelMethod lookupLabelMethod,
+                                                      AccumulateFollowingMethod accumulateFollowingMethod) {
+        Set<String> accumulationSet = new HashSet<>();
+
+        for (CustomChannelInfoJson customChannelInfo : customChannelInfoJsonList) {
+            String searchLabel = searchLabelMethod.getSearchLabel(customChannelInfo);
+            boolean isEmptySearchLabel = StringUtils.isEmpty(searchLabel);
+
+            if (isEmptySearchLabel && (!emptyIsAllowed)) {
+                throw new IllegalArgumentException(String.format("Custom channel searchLabel [%s] must have valid %s",
+                        customChannelInfo.getLabel(), informationTypeString));
+            }
+
+            if ((!isEmptySearchLabel) && (!accumulationSet.contains(searchLabel))) {
+                if (null == lookupLabelMethod.lookupWithLabel(searchLabel)) {
+                    throw new IllegalArgumentException(String.format("No %s named [%s] for custom channel [%s]",
+                            informationTypeString, searchLabel, customChannelInfo.getLabel()));
+                }
+                accumulationSet.add(searchLabel);
+            }
+
+            //when looking to a parent or original channel, this channel can be a parent/original of the following ones
+            if (null != accumulateFollowingMethod) {
+                accumulationSet.add(accumulateFollowingMethod.accumulateFollowing(customChannelInfo));
+            }
+        }
+    }
+
+    private static void ensureValidOrgIds(List<CustomChannelInfoJson> customChannelInfoJsonList) {
+        Set<Long> orgSet = new HashSet<>();
+
+        for (CustomChannelInfoJson customChannelInfo : customChannelInfoJsonList) {
+            Long orgId = customChannelInfo.getPeripheralOrgId();
+
+            if (null == orgId) {
+                throw new IllegalArgumentException("Custom channel info [" +
+                        customChannelInfo.getLabel() + "] must have a defined OrgId");
+            }
+
+            if (!orgSet.contains(orgId)) {
+                Org org = OrgFactory.lookupById(orgId);
+                if (null == org) {
+                    throw new IllegalArgumentException("No org id found [" + orgId +
+                            "] for custom channel [" + customChannelInfo.getLabel() + "]");
+                }
+                orgSet.add(orgId);
+            }
         }
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
@@ -112,12 +112,12 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
     }
 
     public static Channel createBaseChannel(User user,
-                                ChannelFamily fam) throws Exception {
+                                            ChannelFamily fam) throws Exception {
         Channel c = createTestChannel(null, fam);
         ProductName pn = lookupOrCreateProductName(ChannelManager.RHEL_PRODUCT_NAME);
         c.setProductName(pn);
         ChannelFactory.save(c);
-        return (Channel)TestUtils.saveAndReload(c);
+        return (Channel) TestUtils.saveAndReload(c);
     }
 
     public static Channel createTestChannel(User user) throws Exception {
@@ -137,15 +137,15 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
 
         ContentSourceType type = ChannelManager.findCompatibleContentSourceType(c.getChannelArch());
         contentSourceUrls.stream()
-                         .map(url -> {
-                             ContentSource cs = new ContentSource();
-                             cs.setLabel(c.getLabel() + "-CS-" + RandomStringUtils.randomAlphabetic(8));
-                             cs.setOrg(user.getOrg());
-                             cs.setType(type);
-                             cs.setSourceUrl(url);
-                             return TestUtils.saveAndReload(cs);
-                         })
-                         .forEach(c.getSources()::add);
+                .map(url -> {
+                    ContentSource cs = new ContentSource();
+                    cs.setLabel(c.getLabel() + "-CS-" + RandomStringUtils.randomAlphabetic(8));
+                    cs.setOrg(user.getOrg());
+                    cs.setType(type);
+                    cs.setSourceUrl(url);
+                    return TestUtils.saveAndReload(cs);
+                })
+                .forEach(c.getSources()::add);
 
         ChannelFactory.save(c);
         return c;
@@ -163,7 +163,7 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
 
     public static Channel createTestChannel(Org org) throws Exception {
         ChannelFamily cfam = org.getPrivateChannelFamily();
-        Channel c =  ChannelFactoryTest.createTestChannel(org, cfam);
+        Channel c = ChannelFactoryTest.createTestChannel(org, cfam);
         ChannelFactory.save(c);
         return c;
     }
@@ -177,7 +177,7 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
     /**
      * Create a test channel setting the GPGCheck flag via a parameter.
      *
-     * @param user the user
+     * @param user       the user
      * @param gpgCheckIn the GPGCheck flag to set
      * @return the test channel
      * @throws Exception
@@ -236,6 +236,7 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
 
     /**
      * TODO: need to fix this test when we put errata management back in.
+     *
      * @throws Exception something bad happened
      */
     @Test
@@ -243,7 +244,7 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
         User user = UserTestUtils.findNewUser("testUser",
                 "testOrg" + this.getClass().getSimpleName());
         ChannelManager.
-            getChannelsWithClonableErrata(user.getOrg());
+                getChannelsWithClonableErrata(user.getOrg());
 
         Channel original = ChannelFactoryTest.createTestChannel(user);
         Channel clone = ChannelFactoryTest.createTestClonedChannel(original, user);
@@ -252,7 +253,7 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
 
         List<ClonedChannel> channels =
                 ChannelFactory.getChannelsWithClonableErrata(
-                user.getOrg());
+                        user.getOrg());
 
         assertFalse(channels.isEmpty());
     }
@@ -378,7 +379,7 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
         ChannelFactory.save(original);
         TestUtils.flushAndEvict(original);
 
-        original = (Channel)reload(original);
+        original = (Channel) reload(original);
         assertEquals(1, ChannelFactory.getPackageCount(original));
     }
 
@@ -386,8 +387,9 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
      * Create a test cloned channel. NOTE: This function does not copy its
      * original's package list like a real clone would. It is only useful for
      * testing purposes.
+     *
      * @param original Channel to be cloned
-     * @param user the user
+     * @param user     the user
      * @return a test cloned channel
      */
     public static Channel createTestClonedChannel(Channel original, User user) {
@@ -661,6 +663,7 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
 
     /**
      * Test "ChannelFactory.findAllByUserOrderByChild"
+     *
      * @throws Exception
      */
     @Test
@@ -702,6 +705,7 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
         assertEquals("a_child1", channels.get(2).getLabel());
         assertEquals("b_parent3", channels.get(3).getLabel());
     }
+
     @Test
     public void testChannelSyncFlag() throws Exception {
 

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1009,7 +1009,16 @@ public class ContentSyncManager {
     }
 
     private void refreshCustomRepoAuthentication(List<SCCRepositoryJson> customReposIn, SCCCredentials creds) {
-        IssHub issHub = creds.getIssHub();
+        refreshCustomRepo(customReposIn, creds.getIssHub());
+    }
+
+    /**
+     * refreshes custom repositories
+     *
+     * @param customReposIn list of SCCRepositoryJson objects {@link SCCRepositoryJson}
+     * @param issHub        {@link IssHub} to use
+     */
+    public void refreshCustomRepo(List<SCCRepositoryJson> customReposIn, IssHub issHub) {
         if (issHub == null) {
             LOG.debug("Only Peripheral server manage custom channels via SCC API");
             return;

--- a/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
+++ b/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
@@ -166,16 +166,28 @@ public class MgrSyncUtils {
 
     /**
      * Find a {@link ChannelProduct} or create it if necessary and return it.
+     *
      * @param product product to find or create
      * @return channel product
      */
     public static ChannelProduct findOrCreateChannelProduct(SUSEProduct product) {
+        return findOrCreateChannelProduct(product.getName(), product.getVersion());
+    }
+
+    /**
+     * Find a {@link ChannelProduct} or create it if necessary and return it.
+     *
+     * @param productName    name of the product to find or create
+     * @param productVersion version of the product to find or create
+     * @return channel product
+     */
+    public static ChannelProduct findOrCreateChannelProduct(String productName, String productVersion) {
         ChannelProduct p = ChannelFactory.findChannelProduct(
-                product.getName(), product.getVersion());
+                productName, productVersion);
         if (p == null) {
             p = new ChannelProduct();
-            p.setProduct(product.getName());
-            p.setVersion(product.getVersion());
+            p.setProduct(productName);
+            p.setVersion(productVersion);
             p.setBeta(false);
             ChannelFactory.save(p);
         }

--- a/java/code/src/com/suse/manager/hub/HubController.java
+++ b/java/code/src/com/suse/manager/hub/HubController.java
@@ -33,6 +33,7 @@ import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.taskomatic.task.ReportDBHelper;
 
 import com.suse.manager.model.hub.ChannelInfoJson;
+import com.suse.manager.model.hub.CustomChannelInfoJson;
 import com.suse.manager.model.hub.IssAccessToken;
 import com.suse.manager.model.hub.IssRole;
 import com.suse.manager.model.hub.ManagerInfoJson;
@@ -50,6 +51,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -104,6 +106,8 @@ public class HubController {
                 asJson(usingTokenAuthentication(allowingOnlyPeripheral(this::listAllPeripheralChannels))));
         post("/hub/addVendorChannels",
                 asJson(usingTokenAuthentication(allowingOnlyPeripheral(this::addVendorChannels))));
+        post("/hub/addCustomChannels",
+                asJson(usingTokenAuthentication(allowingOnlyPeripheral(this::addCustomChannels))));
     }
 
     private String setHubDetails(Request request, Response response, IssAccessToken accessToken) {
@@ -282,19 +286,39 @@ public class HubController {
             return badRequest(response, "Invalid data: invalid vendor channel label list");
         }
 
-        try {
-            List<ChannelInfoJson> createdVendorChannelInfoList =
-                    hubManager.addVendorChannels(token, vendorChannelLabelList)
-                    .stream()
-                    .map(ch -> new ChannelInfoJson(ch.getId(), ch.getName(), ch.getLabel(), ch.getSummary(),
-                            ((null == ch.getOrg()) ? null : ch.getOrg().getId()),
-                            (null == ch.getParentChannel()) ? null : ch.getParentChannel().getId()))
-                    .toList();
-            return success(response, createdVendorChannelInfoList);
+        List<ChannelInfoJson> createdVendorChannelInfoList =
+                hubManager.addVendorChannels(token, vendorChannelLabelList)
+                        .stream()
+                        .map(ch -> new ChannelInfoJson(ch.getId(), ch.getName(), ch.getLabel(), ch.getSummary(),
+                                ((null == ch.getOrg()) ? null : ch.getOrg().getId()),
+                                (null == ch.getParentChannel()) ? null : ch.getParentChannel().getId()))
+                        .toList();
+        return success(response, createdVendorChannelInfoList);
+    }
+
+
+    private String addCustomChannels(Request request, Response response, IssAccessToken token) {
+        Map<String, String> requestList = GSON.fromJson(request.body(), Map.class);
+
+        if ((null == requestList) || (!requestList.containsKey("customchannellist"))) {
+            return badRequest(response, "Invalid data: missing customchannellist entry");
         }
-        catch (Exception e) {
-            LOGGER.error("Bad Request: ", e);
-            return badRequest(response, e.getMessage());
+
+        List<CustomChannelInfoJson> customChannelInfoList = Arrays.asList(
+                GSON.fromJson(requestList.get("customchannellist"), CustomChannelInfoJson[].class));
+
+        if (customChannelInfoList.isEmpty()) {
+            LOGGER.error("Bad Request: invalid custom channels list");
+            return badRequest(response, "Invalid data: invalid custom channels list");
         }
+
+        List<ChannelInfoJson> createdCustomChannelsInfoList =
+                hubManager.addCustomChannels(token, customChannelInfoList)
+                        .stream()
+                        .map(ch -> new ChannelInfoJson(ch.getId(), ch.getName(), ch.getLabel(), ch.getSummary(),
+                                ((null == ch.getOrg()) ? null : ch.getOrg().getId()),
+                                (null == ch.getParentChannel()) ? null : ch.getParentChannel().getId()))
+                        .toList();
+        return success(response, createdCustomChannelsInfoList);
     }
 }

--- a/java/code/src/com/suse/manager/hub/test/ControllerTestUtils.java
+++ b/java/code/src/com/suse/manager/hub/test/ControllerTestUtils.java
@@ -14,6 +14,7 @@ package com.suse.manager.hub.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -44,6 +45,7 @@ import com.suse.manager.model.hub.HubFactory;
 import com.suse.manager.model.hub.IssHub;
 import com.suse.manager.model.hub.IssPeripheral;
 import com.suse.manager.model.hub.IssRole;
+import com.suse.manager.model.hub.ModifyCustomChannelInfoJson;
 import com.suse.manager.model.hub.TokenType;
 import com.suse.manager.webui.utils.gson.ResultJson;
 import com.suse.manager.webui.utils.token.IssTokenBuilder;
@@ -430,5 +432,159 @@ public class ControllerTestUtils {
         catch (IllegalArgumentException e) {
             fail("addCustomChannels API should not throw");
         }
+    }
+
+    public ModifyCustomChannelInfoJson createValidModifyCustomChInfo() {
+        return createValidModifyCustomChInfo("customCh");
+    }
+
+    public ModifyCustomChannelInfoJson createValidModifyCustomChInfo(String channelLabel) {
+        User testPeripheralUser = UserTestUtils.findNewUser("peripheral_user_", "peripheral_org_", true);
+        boolean isGpgCheck = true;
+        boolean isInstallerUpdates = true;
+        ModifyCustomChannelInfoJson info = new ModifyCustomChannelInfoJson(channelLabel);
+
+        info.setPeripheralOrgId(testPeripheralUser.getOrg().getId());
+        info.setOriginalChannelLabel("");
+
+        info.setBaseDir("baseDir_" + channelLabel);
+        info.setName("name_" + channelLabel);
+        info.setSummary("summary_" + channelLabel);
+        info.setDescription("description_" + channelLabel);
+        info.setProductNameLabel("productNameLabel");
+        info.setGpgCheck(isGpgCheck);
+        info.setGpgKeyUrl("gpgKeyUrl_" + channelLabel);
+        info.setGpgKeyId("gpgKeyId");
+        info.setGpgKeyFp("gpgKeyFp_" + channelLabel);
+        info.setEndOfLifeDate(createDateUtil(2096, 10, 22));
+        info.setChannelProductProduct("channelProductProduct");
+        info.setChannelProductVersion("channelProductVersion");
+        info.setChannelAccess("chAccess"); // max 10
+        info.setMaintainerName("maintainerName_" + channelLabel);
+        info.setMaintainerEmail("maintainerEmail_" + channelLabel);
+        info.setMaintainerPhone("maintainerPhone_" + channelLabel);
+        info.setSupportPolicy("supportPolicy_" + channelLabel);
+        info.setUpdateTag("updateTag_" + channelLabel);
+        info.setInstallerUpdates(isInstallerUpdates);
+
+        return info;
+    }
+
+    public Object testModifyCustomChannelsApiCall(String serverFqdnIn,
+                                                  List<ModifyCustomChannelInfoJson> modifyCustomChannelInfoListIn)
+            throws Exception {
+        String apiUnderTest = "/hub/modifyCustomChannels";
+
+        Map<String, String> bodyMapIn = new HashMap<>();
+        bodyMapIn.put("modifycustomchannellist", Json.GSON.toJson(modifyCustomChannelInfoListIn));
+
+        return withServerFqdn(serverFqdnIn)
+                .withApiEndpoint(apiUnderTest)
+                .withHttpMethod(HttpMethod.post)
+                .withRole(IssRole.PERIPHERAL)
+                .withBearerTokenInHeaders()
+                .withBody(bodyMapIn)
+                .simulateControllerApiCall();
+    }
+
+    public void checkModifyCustomChannelsApiNotThrowing(String serverFqdnIn,
+                                                        List<ModifyCustomChannelInfoJson> modifyCustomChannelInfoListIn)
+            throws Exception {
+
+        try {
+            String answer = (String) testModifyCustomChannelsApiCall(serverFqdnIn, modifyCustomChannelInfoListIn);
+
+            List<ChannelInfoJson> peripheralCreatedCustomChInfo =
+                    Arrays.asList(Json.GSON.fromJson(answer, ChannelInfoJson[].class));
+
+            assertNotNull(peripheralCreatedCustomChInfo,
+                    "addCustomChannels API failing when creating peripheral channel");
+
+        }
+        catch (IllegalArgumentException e) {
+            fail("modifyCustomChannels API should not throw");
+        }
+    }
+
+    public void checkModifyCustomChannelsApiThrows(String serverFqdnIn,
+                                                   List<ModifyCustomChannelInfoJson> modifyCustomChannelInfoListIn,
+                                                   String errorStartsWith) throws Exception {
+        try {
+            String answer = (String) testModifyCustomChannelsApiCall(serverFqdnIn, modifyCustomChannelInfoListIn);
+
+            ResultJson<?> result = Json.GSON.fromJson(answer, ResultJson.class);
+            assertFalse(result.isSuccess(),
+                    "modifyCustomChannels API not failing when creating peripheral channel with " +
+                            errorStartsWith);
+            assertEquals("Internal Server Error", result.getMessages().get(0));
+            assertTrue(result.getMessages().get(1).startsWith(errorStartsWith),
+                    "Wrong expected start of error message: [" + result.getMessages().get(1) + "]");
+        }
+        catch (IllegalArgumentException e) {
+            fail("modifyCustomChannels API should not throw");
+        }
+    }
+
+    private static void checkEqualIfModified(Object modified, Object pristine) {
+        if (null != modified) {
+            assertEquals(modified, pristine);
+        }
+    }
+
+    private static void checkDifferentIfModified(Object modified, Object pristine) {
+        if (null != modified) {
+            assertNotEquals(modified, pristine);
+        }
+    }
+
+    @FunctionalInterface
+    private interface CheckMethod {
+        void checkCompatible(Object modified, Object pristine);
+    }
+
+    public void checkEqualModifications(ModifyCustomChannelInfoJson modifyInfo, Channel ch) {
+        checkModifications(modifyInfo, ch, ControllerTestUtils::checkEqualIfModified);
+    }
+
+    public void checkDifferentModifications(ModifyCustomChannelInfoJson modifyInfo, Channel ch) {
+        checkModifications(modifyInfo, ch, ControllerTestUtils::checkDifferentIfModified);
+    }
+
+    private void checkModifications(ModifyCustomChannelInfoJson modifyInfo, Channel ch, CheckMethod checkMethod) {
+        assertEquals(modifyInfo.getLabel(), ch.getLabel());
+
+        if (null != modifyInfo.getPeripheralOrgId()) {
+            checkMethod.checkCompatible(modifyInfo.getPeripheralOrgId(), ch.getOrg().getId());
+        }
+
+        checkMethod.checkCompatible(modifyInfo.getOriginalChannelLabel(), ch.getOriginal().getLabel());
+
+        checkMethod.checkCompatible(modifyInfo.getBaseDir(), ch.getBaseDir());
+        checkMethod.checkCompatible(modifyInfo.getName(), ch.getName());
+        checkMethod.checkCompatible(modifyInfo.getSummary(), ch.getSummary());
+        checkMethod.checkCompatible(modifyInfo.getDescription(), ch.getDescription());
+        checkMethod.checkCompatible(modifyInfo.getProductNameLabel(), ch.getProductName().getLabel());
+        checkMethod.checkCompatible(modifyInfo.isGpgCheck(), ch.isGPGCheck());
+        checkMethod.checkCompatible(modifyInfo.getGpgKeyUrl(), ch.getGPGKeyUrl());
+        checkMethod.checkCompatible(modifyInfo.getGpgKeyId(), ch.getGPGKeyId());
+        checkMethod.checkCompatible(modifyInfo.getGpgKeyFp(), ch.getGPGKeyFp());
+        checkMethod.checkCompatible(modifyInfo.getEndOfLifeDate().toString(), ch.getEndOfLife().toString());
+
+        checkMethod.checkCompatible(modifyInfo.getChannelProductProduct(), ch.getProduct().getProduct());
+        checkMethod.checkCompatible(modifyInfo.getChannelProductVersion(), ch.getProduct().getVersion());
+        checkMethod.checkCompatible(modifyInfo.getChannelAccess(), ch.getAccess());
+        checkMethod.checkCompatible(modifyInfo.getMaintainerName(), ch.getMaintainerName());
+        checkMethod.checkCompatible(modifyInfo.getMaintainerEmail(), ch.getMaintainerEmail());
+        checkMethod.checkCompatible(modifyInfo.getMaintainerPhone(), ch.getMaintainerPhone());
+        checkMethod.checkCompatible(modifyInfo.getSupportPolicy(), ch.getSupportPolicy());
+        checkMethod.checkCompatible(modifyInfo.getUpdateTag(), ch.getUpdateTag());
+        checkMethod.checkCompatible(modifyInfo.isInstallerUpdates(), ch.isInstallerUpdates());
+    }
+
+    public void createTestChannel(ModifyCustomChannelInfoJson modifyInfo, User userIn) throws Exception {
+        ChannelFamily cfam = ChannelFamilyFactoryTest.createTestChannelFamily();
+        String query = "ChannelArch.findById";
+        ChannelArch arch = (ChannelArch) TestUtils.lookupFromCacheById(500L, query);
+        ChannelFactoryTest.createTestChannel(modifyInfo.getName(), modifyInfo.getLabel(), userIn.getOrg(), arch, cfam);
     }
 }

--- a/java/code/src/com/suse/manager/hub/test/ControllerTestUtils.java
+++ b/java/code/src/com/suse/manager/hub/test/ControllerTestUtils.java
@@ -13,8 +13,8 @@ package com.suse.manager.hub.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;

--- a/java/code/src/com/suse/manager/hub/test/ControllerTestUtils.java
+++ b/java/code/src/com/suse/manager/hub/test/ControllerTestUtils.java
@@ -11,15 +11,41 @@
 
 package com.suse.manager.hub.test;
 
-import com.redhat.rhn.common.hibernate.HibernateFactory;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.hibernate.ConnectionManager;
+import com.redhat.rhn.common.hibernate.ConnectionManagerFactory;
+import com.redhat.rhn.common.hibernate.ReportDbHibernateFactory;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelArch;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.channel.ChannelFamily;
+import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
+import com.redhat.rhn.domain.channel.test.ChannelFamilyFactoryTest;
+import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.product.test.SUSEProductTestUtils;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.taskomatic.task.ReportDBHelper;
 import com.redhat.rhn.testing.RhnMockHttpServletResponse;
 import com.redhat.rhn.testing.SparkTestUtils;
+import com.redhat.rhn.testing.TestUtils;
+import com.redhat.rhn.testing.UserTestUtils;
 
+import com.suse.manager.model.hub.ChannelInfoJson;
+import com.suse.manager.model.hub.CustomChannelInfoJson;
 import com.suse.manager.model.hub.HubFactory;
 import com.suse.manager.model.hub.IssHub;
 import com.suse.manager.model.hub.IssPeripheral;
 import com.suse.manager.model.hub.IssRole;
 import com.suse.manager.model.hub.TokenType;
+import com.suse.manager.webui.utils.gson.ResultJson;
 import com.suse.manager.webui.utils.token.IssTokenBuilder;
 import com.suse.manager.webui.utils.token.Token;
 import com.suse.manager.webui.utils.token.TokenBuildingException;
@@ -27,7 +53,12 @@ import com.suse.manager.webui.utils.token.TokenParsingException;
 import com.suse.utils.Json;
 
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -97,13 +128,20 @@ public class ControllerTestUtils {
     public Object simulateControllerApiCall() throws Exception {
         HubFactory hubFactory = new HubFactory();
         hubFactory.saveToken(serverFqdn, authBearerToken, TokenType.ISSUED, authBearerTokenExpiration);
+
         if (null != role) {
             switch (role) {
                 case HUB:
-                    hubFactory.save(new IssHub(serverFqdn, ""));
+                    Optional<IssHub> hub = hubFactory.lookupIssHubByFqdn(serverFqdn);
+                    if (hub.isEmpty()) {
+                        hubFactory.save(new IssHub(serverFqdn, ""));
+                    }
                     break;
                 case PERIPHERAL:
-                    hubFactory.save(new IssPeripheral(serverFqdn, ""));
+                    Optional<IssPeripheral> peripheral = hubFactory.lookupIssPeripheralByFqdn(serverFqdn);
+                    if (peripheral.isEmpty()) {
+                        hubFactory.save(new IssPeripheral(serverFqdn, ""));
+                    }
                     break;
                 default:
                     throw new IllegalArgumentException("unsupported role " + role.getLabel());
@@ -117,8 +155,7 @@ public class ControllerTestUtils {
     }
 
     public static Object simulateApiEndpointCall(String apiEndpoint, HttpMethod httpMethod,
-                                                 String authBearerToken, String body)
-            throws Exception {
+                                                 String authBearerToken, String body) throws Exception {
         Optional<RouteMatch> routeMatch = spark.Spark.routes()
                 .stream()
                 .filter(e -> apiEndpoint.equals(e.getMatchUri()))
@@ -140,8 +177,258 @@ public class ControllerTestUtils {
                 SparkTestUtils.createMockRequestWithBody(apiEndpoint, httpHeaders, body);
 
         Response dummyTestResponse = RequestResponseFactory.create(new RhnMockHttpServletResponse());
-        Object returnObject = routeImpl.handle(dummyTestRequest, dummyTestResponse);
-        HibernateFactory.rollbackTransaction();
-        return returnObject;
+        return routeImpl.handle(dummyTestRequest, dummyTestResponse);
+    }
+
+    public String createTestUserName() {
+        return "testUser" + TestUtils.randomString();
+    }
+
+    public String createTestPassword() {
+        return "testPassword" + TestUtils.randomString();
+    }
+
+    public void createReportDbUser(String testReportDbUserName, String testReportDbPassword) {
+        String dbname = Config.get().getString(ConfigDefaults.REPORT_DB_NAME, "");
+        ConnectionManager localRcm = ConnectionManagerFactory.localReportingConnectionManager();
+        ReportDbHibernateFactory localRh = new ReportDbHibernateFactory(localRcm);
+        ReportDBHelper dbHelper = ReportDBHelper.INSTANCE;
+
+        dbHelper.createDBUser(localRh.getSession(), dbname, testReportDbUserName, testReportDbPassword);
+        localRcm.commitTransaction();
+    }
+
+    public boolean existsReportDbUser(String testReportDbUserName) {
+        ConnectionManager localRcm = ConnectionManagerFactory.localReportingConnectionManager();
+        ReportDbHibernateFactory localRh = new ReportDbHibernateFactory(localRcm);
+        ReportDBHelper dbHelper = ReportDBHelper.INSTANCE;
+
+        return dbHelper.hasDBUser(localRh.getSession(), testReportDbUserName);
+    }
+
+    public void cleanupReportDbUser(String testReportDbUserName) {
+        ConnectionManager localRcm = ConnectionManagerFactory.localReportingConnectionManager();
+        ReportDbHibernateFactory localRh = new ReportDbHibernateFactory(localRcm);
+        ReportDBHelper dbHelper = ReportDBHelper.INSTANCE;
+
+        dbHelper.dropDBUser(localRh.getSession(), testReportDbUserName);
+        localRcm.commitTransaction();
+    }
+
+    public Channel createVendorBaseChannel(String name, String label) throws Exception {
+        Org nullOrg = null;
+        ChannelFamily cfam = ChannelFamilyFactoryTest.createNullOrgTestChannelFamily();
+        String query = "ChannelArch.findById";
+        ChannelArch arch = (ChannelArch) TestUtils.lookupFromCacheById(500L, query);
+        return ChannelFactoryTest.createTestChannel(name, label, nullOrg, arch, cfam);
+    }
+
+    public Channel createVendorChannel(String name, String label, Channel vendorBaseChannel) throws Exception {
+        Channel vendorChannel = createVendorBaseChannel(name, label);
+        vendorChannel.setParentChannel(vendorBaseChannel);
+        vendorChannel.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha512"));
+        ChannelFactory.save(vendorChannel);
+        return vendorChannel;
+    }
+
+    public Date createDateUtil(int year, int month, int dayOfMonth) {
+        GregorianCalendar cal = new GregorianCalendar(year, month, dayOfMonth);
+        return cal.getTime();
+    }
+
+    public boolean isNowUtil(Date dateIn) {
+        GregorianCalendar cal = new GregorianCalendar();
+        Date nowDate = createDateUtil(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH));
+
+        return (dateIn.getTime() - nowDate.getTime() < 24L * 60L * 60L * 1000L);
+    }
+
+    public CustomChannelInfoJson createCustomChannelInfoJson(Long orgId,
+                                                             String channelLabel,
+                                                             String parentChannelLabel,
+                                                             String originalChannelLabel,
+                                                             boolean isGpgCheck,
+                                                             boolean isInstallerUpdates,
+                                                             String archLabel,
+                                                             String checksumLabel,
+                                                             Date endOfLifeDate) {
+        CustomChannelInfoJson info = new CustomChannelInfoJson(channelLabel);
+
+        info.setPeripheralOrgId(orgId);
+        info.setParentChannelLabel(parentChannelLabel);
+        info.setChannelArchLabel(archLabel);
+        info.setBaseDir("baseDir_" + channelLabel);
+        info.setName("name_" + channelLabel);
+        info.setSummary("summary_" + channelLabel);
+        info.setDescription("description_" + channelLabel);
+        info.setProductNameLabel("productNameLabel");
+        info.setGpgCheck(isGpgCheck);
+        info.setGpgKeyUrl("gpgKeyUrl_" + channelLabel);
+        info.setGpgKeyId("gpgKeyId");
+        info.setGpgKeyFp("gpgKeyFp_" + channelLabel);
+        info.setEndOfLifeDate(endOfLifeDate);
+        info.setChecksumTypeLabel(checksumLabel);
+        info.setChannelProductProduct("channelProductProduct");
+        info.setChannelProductVersion("channelProductVersion");
+        info.setChannelAccess("chAccess"); // max 10
+        info.setMaintainerName("maintainerName_" + channelLabel);
+        info.setMaintainerEmail("maintainerEmail_" + channelLabel);
+        info.setMaintainerPhone("maintainerPhone_" + channelLabel);
+        info.setSupportPolicy("supportPolicy_" + channelLabel);
+        info.setUpdateTag("updateTag_" + channelLabel);
+        info.setInstallerUpdates(isInstallerUpdates);
+
+        info.setOriginalChannelLabel(originalChannelLabel);
+
+        return info;
+    }
+
+    public void testCustomChannel(Channel ch, Long peripheralOrgId,
+                                  boolean isGpgCheck,
+                                  boolean isInstallerUpdates,
+                                  String archLabel,
+                                  String checksumLabel,
+                                  Date endOfLifeDate) {
+        ChannelArch testChannelArch = ChannelFactory.findArchByLabel(archLabel);
+        String channelLabel = ch.getLabel();
+
+        if (null != peripheralOrgId) {
+            assertEquals(peripheralOrgId, ch.getOrg().getId());
+        }
+        else {
+            assertNull(ch.getOrg());
+        }
+
+        assertEquals(testChannelArch, ch.getChannelArch());
+        assertEquals("baseDir_" + channelLabel, ch.getBaseDir());
+        assertEquals("name_" + channelLabel, ch.getName());
+        assertEquals("summary_" + channelLabel, ch.getSummary());
+        assertEquals("description_" + channelLabel, ch.getDescription());
+        assertEquals(isGpgCheck, ch.isGPGCheck());
+        assertEquals("gpgKeyUrl_" + channelLabel, ch.getGPGKeyUrl());
+        assertEquals("gpgKeyId", ch.getGPGKeyId());
+        assertEquals("gpgKeyFp_" + channelLabel, ch.getGPGKeyFp());
+
+        assertEquals(endOfLifeDate, ch.getEndOfLife());
+        assertEquals(checksumLabel, ch.getChecksumType().getLabel());
+        assertTrue(isNowUtil(ch.getLastModified()));
+
+        assertEquals("chAccess", ch.getAccess());
+
+        assertEquals("maintainerName_" + channelLabel, ch.getMaintainerName());
+        assertEquals("maintainerEmail_" + channelLabel, ch.getMaintainerEmail());
+        assertEquals("maintainerPhone_" + channelLabel, ch.getMaintainerPhone());
+
+        assertEquals("supportPolicy_" + channelLabel, ch.getSupportPolicy());
+        assertEquals("updateTag_" + channelLabel, ch.getUpdateTag());
+        assertEquals(isInstallerUpdates, ch.isInstallerUpdates());
+
+        assertEquals("productNameLabel", ch.getProductName().getLabel());
+        assertEquals("channelProductProduct", ch.getProduct().getProduct());
+        assertEquals("channelProductVersion", ch.getProduct().getVersion());
+    }
+
+    public String createTestVendorChannels(User userIn, String serverFqdnIn) throws Exception {
+
+        //SUSE Linux Enterprise Server 11 SP3 x86_64
+        return createTestVendorChannels(userIn, serverFqdnIn,
+                "SLES11-SP3-Pool for x86_64", "sles11-sp3-pool-x86_64", true,
+                "SLES11-SP3-Updates for x86_64", "sles11-sp3-updates-x86_64", true);
+
+    }
+
+    public String createTestVendorChannels(User userIn, String serverFqdnIn,
+                                           String vendorBaseChannelTemplateNameIn,
+                                           String vendorBaseChannelTemplateLabelIn,
+                                           boolean createBaseChannelIn,
+                                           String vendorChannelTemplateNameIn,
+                                           String vendorChannelTemplateLabelIn,
+                                           boolean createChildChannelIn) throws Exception {
+
+        SUSEProductTestUtils.createVendorSUSEProductEnvironment(userIn, null, true);
+
+        Channel vendorBaseChannel = null;
+        if (createBaseChannelIn) {
+            vendorBaseChannel = createVendorBaseChannel(vendorBaseChannelTemplateNameIn,
+                    vendorBaseChannelTemplateLabelIn);
+        }
+        if (createChildChannelIn) {
+            createVendorChannel(vendorChannelTemplateNameIn, vendorChannelTemplateLabelIn, vendorBaseChannel);
+        }
+
+        Map<String, String> bodyMapIn = new HashMap<>();
+        bodyMapIn.put("vendorchannellabellist", Json.GSON.toJson(List.of(vendorChannelTemplateLabelIn)));
+
+        return (String) withServerFqdn(serverFqdnIn)
+                .withApiEndpoint("/hub/addVendorChannels")
+                .withHttpMethod(HttpMethod.post)
+                .withRole(IssRole.PERIPHERAL)
+                .withBearerTokenInHeaders()
+                .withBody(bodyMapIn)
+                .simulateControllerApiCall();
+    }
+
+    public CustomChannelInfoJson createValidCustomChInfo() {
+        return createValidCustomChInfo("customCh");
+    }
+
+    public CustomChannelInfoJson createValidCustomChInfo(String channelLabel) {
+        User testPeripheralUser = UserTestUtils.findNewUser("peripheral_user_", "peripheral_org_", true);
+        return createCustomChannelInfoJson(testPeripheralUser.getOrg().getId(),
+                channelLabel, "", "",
+                true, true, "channel-s390", "sha256",
+                createDateUtil(2096, 10, 22));
+    }
+
+    public Object testAddCustomChannelsApiCall(String serverFqdnIn,
+                                               List<CustomChannelInfoJson> customChannelInfoListIn) throws Exception {
+        String apiUnderTest = "/hub/addCustomChannels";
+
+        Map<String, String> bodyMapIn = new HashMap<>();
+        bodyMapIn.put("customchannellist", Json.GSON.toJson(customChannelInfoListIn));
+
+        return withServerFqdn(serverFqdnIn)
+                .withApiEndpoint(apiUnderTest)
+                .withHttpMethod(HttpMethod.post)
+                .withRole(IssRole.PERIPHERAL)
+                .withBearerTokenInHeaders()
+                .withBody(bodyMapIn)
+                .simulateControllerApiCall();
+    }
+
+    public void checkAddCustomChannelsApiNotThrowing(String serverFqdnIn,
+                                                     List<CustomChannelInfoJson> customChannelInfoListIn)
+            throws Exception {
+        try {
+            String answer = (String) testAddCustomChannelsApiCall(serverFqdnIn, customChannelInfoListIn);
+
+            List<ChannelInfoJson> peripheralCreatedCustomChInfo =
+                    Arrays.asList(Json.GSON.fromJson(answer, ChannelInfoJson[].class));
+
+            assertNotNull(peripheralCreatedCustomChInfo,
+                    "addCustomChannels API failing when creating peripheral channel");
+        }
+        catch (IllegalArgumentException e) {
+            fail("addCustomChannels API should not throw");
+        }
+    }
+
+    public void checkAddCustomChannelsApiThrows(String serverFqdnIn,
+                                                List<CustomChannelInfoJson> customChannelInfoListIn,
+                                                String errorStartsWith) throws Exception {
+        try {
+            String answer = (String) testAddCustomChannelsApiCall(serverFqdnIn, customChannelInfoListIn);
+
+            ResultJson<?> result = Json.GSON.fromJson(answer, ResultJson.class);
+            assertFalse(result.isSuccess(),
+                    "addCustomChannels API not failing when creating peripheral channel with " +
+                            errorStartsWith);
+            assertEquals("Internal Server Error", result.getMessages().get(0));
+            assertTrue(result.getMessages().get(1).startsWith(errorStartsWith),
+                    "Wrong expected start of error message: [" + result.getMessages().get(1) + "]");
+        }
+        catch (IllegalArgumentException e) {
+            fail("addCustomChannels API should not throw");
+        }
     }
 }

--- a/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
@@ -47,8 +47,11 @@ import com.suse.manager.hub.HubController;
 import com.suse.manager.model.hub.ChannelInfoJson;
 import com.suse.manager.model.hub.CustomChannelInfoJson;
 import com.suse.manager.model.hub.IssAccessToken;
+import com.suse.manager.model.hub.CustomChannelInfoJson;
+import com.suse.manager.model.hub.IssAccessToken;
 import com.suse.manager.model.hub.IssRole;
 import com.suse.manager.model.hub.ManagerInfoJson;
+import com.suse.manager.model.hub.ModifyCustomChannelInfoJson;
 import com.suse.manager.model.hub.OrgInfoJson;
 import com.suse.manager.webui.utils.gson.ResultJson;
 import com.suse.manager.webui.utils.token.IssTokenBuilder;
@@ -114,7 +117,8 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
                 Arguments.of(HttpMethod.get, "/hub/listAllPeripheralOrgs", IssRole.PERIPHERAL),
                 Arguments.of(HttpMethod.get, "/hub/listAllPeripheralChannels", IssRole.PERIPHERAL),
                 Arguments.of(HttpMethod.post, "/hub/addVendorChannels", IssRole.PERIPHERAL),
-                Arguments.of(HttpMethod.post, "/hub/addCustomChannels", IssRole.PERIPHERAL)
+                Arguments.of(HttpMethod.post, "/hub/addCustomChannels", IssRole.PERIPHERAL),
+                Arguments.of(HttpMethod.post, "/hub/modifyCustomChannels", IssRole.PERIPHERAL)
         );
     }
 
@@ -837,5 +841,94 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         assertEquals(vendorCh.getProduct().getVersion(), productionChInfo.getChannelProductVersion());
         assertEquals("sha512", productionChInfo.getChecksumTypeLabel());
         assertEquals("clone-of-sles11-sp3-updates-x86_64", productionChInfo.getOriginalChannelLabel());
+    }
+
+    @Test
+    public void checkModifyCustomChannels() throws Exception {
+        // cloneDevelCh -> cloneTestCh -> cloneProdCh
+        CustomChannelInfoJson cloneDevelChInfo = testUtils.createValidCustomChInfo("cloneDevelCh");
+
+        CustomChannelInfoJson cloneTestChInfo = testUtils.createValidCustomChInfo("cloneTestCh");
+        cloneTestChInfo.setOriginalChannelLabel("cloneDevelCh");
+
+        CustomChannelInfoJson cloneProdChInfo = testUtils.createValidCustomChInfo("cloneProdCh");
+        cloneProdChInfo.setOriginalChannelLabel("cloneTestCh");
+
+        testUtils.checkAddCustomChannelsApiNotThrowing(DUMMY_SERVER_FQDN,
+                Arrays.asList(cloneDevelChInfo, cloneTestChInfo, cloneProdChInfo));
+
+        Channel cloneDevelCh = ChannelFactory.lookupByLabel("cloneDevelCh");
+        assertNotNull(cloneDevelCh);
+        Channel cloneTestCh = ChannelFactory.lookupByLabel("cloneTestCh");
+        assertNotNull(cloneTestCh);
+        Channel cloneProdCh = ChannelFactory.lookupByLabel("cloneProdCh");
+        assertNotNull(cloneProdCh);
+
+
+        Date anotherEndOfLifeDate = testUtils.createDateUtil(2042, 4, 2);
+        User anotherPeripheralUser = UserTestUtils.findNewUser(
+                "another_peripheral_user_", "another_peripheral_org_", true);
+
+        ModifyCustomChannelInfoJson modifyInfo = new ModifyCustomChannelInfoJson("cloneProdCh");
+        modifyInfo.setPeripheralOrgId(anotherPeripheralUser.getOrg().getId());
+        modifyInfo.setOriginalChannelLabel("cloneDevelCh");
+
+        modifyInfo.setBaseDir("baseDir_diff");
+        modifyInfo.setName("name_diff");
+        modifyInfo.setSummary("summary_diff");
+        modifyInfo.setDescription("description_diff");
+        modifyInfo.setProductNameLabel("productNameLabel_diff");
+        modifyInfo.setGpgCheck(!cloneProdCh.isGPGCheck());
+        modifyInfo.setGpgKeyUrl("gpgKeyUrl_diff");
+        modifyInfo.setGpgKeyId("gpgKeyId_diff");
+        modifyInfo.setGpgKeyFp("gpgKeyFp_diff");
+        modifyInfo.setEndOfLifeDate(anotherEndOfLifeDate);
+
+        modifyInfo.setChannelProductProduct("channelProductProduct_diff");
+        modifyInfo.setChannelProductVersion("channelProductVersion_diff");
+        modifyInfo.setChannelAccess("acc_diff"); //max 10
+        modifyInfo.setMaintainerName("maintainerName__diff");
+        modifyInfo.setMaintainerEmail("maintainerEmail_diff");
+        modifyInfo.setMaintainerPhone("maintainerPhone_diff");
+        modifyInfo.setSupportPolicy("supportPolicy_diff");
+        modifyInfo.setUpdateTag("updateTag_diff");
+        modifyInfo.setInstallerUpdates(!cloneProdCh.isInstallerUpdates());
+
+        testUtils.checkDifferentModifications(modifyInfo, cloneProdCh);
+
+        String answer = (String) testUtils.testModifyCustomChannelsApiCall(DUMMY_SERVER_FQDN, List.of(modifyInfo));
+        List<ChannelInfoJson> peripheralModifiedCustomChInfo =
+                Arrays.asList(Json.GSON.fromJson(answer, ChannelInfoJson[].class));
+
+        assertEquals(1, peripheralModifiedCustomChInfo.size());
+        testUtils.checkEqualModifications(modifyInfo, cloneProdCh);
+    }
+
+    @Test
+    public void ensureNotThrowingWhenModifyingDataIsValid() throws Exception {
+        ModifyCustomChannelInfoJson modifyInfo = testUtils.createValidModifyCustomChInfo("customCh");
+        testUtils.createTestChannel(modifyInfo, user);
+
+        testUtils.checkModifyCustomChannelsApiNotThrowing(DUMMY_SERVER_FQDN, List.of(modifyInfo));
+    }
+
+    @Test
+    public void ensureThrowsWhenModifyingMissingPeriperhalOrg() throws Exception {
+        ModifyCustomChannelInfoJson modifyInfo = testUtils.createValidModifyCustomChInfo("customCh");
+        testUtils.createTestChannel(modifyInfo, user);
+
+        modifyInfo.setPeripheralOrgId(75842L);
+
+        testUtils.checkModifyCustomChannelsApiThrows(DUMMY_SERVER_FQDN, List.of(modifyInfo), "No org id");
+    }
+
+    @Test
+    public void ensureThrowsWhenModifyingMissingOriginalChannelInClonedChannels() throws Exception {
+        ModifyCustomChannelInfoJson modifyInfo = testUtils.createValidModifyCustomChInfo("customCh");
+        testUtils.createTestChannel(modifyInfo, user);
+
+        modifyInfo.setOriginalChannelLabel(modifyInfo.getLabel() + "MISSING");
+
+        testUtils.checkModifyCustomChannelsApiThrows(DUMMY_SERVER_FQDN, List.of(modifyInfo), "No original channel");
     }
 }

--- a/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
@@ -47,8 +47,6 @@ import com.suse.manager.hub.HubController;
 import com.suse.manager.model.hub.ChannelInfoJson;
 import com.suse.manager.model.hub.CustomChannelInfoJson;
 import com.suse.manager.model.hub.IssAccessToken;
-import com.suse.manager.model.hub.CustomChannelInfoJson;
-import com.suse.manager.model.hub.IssAccessToken;
 import com.suse.manager.model.hub.IssRole;
 import com.suse.manager.model.hub.ManagerInfoJson;
 import com.suse.manager.model.hub.ModifyCustomChannelInfoJson;

--- a/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
@@ -16,33 +16,36 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.asJson;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spark.Spark.post;
 
-import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
-import com.redhat.rhn.common.hibernate.ConnectionManager;
-import com.redhat.rhn.common.hibernate.ConnectionManagerFactory;
-import com.redhat.rhn.common.hibernate.ReportDbHibernateFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelArch;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.ChannelFamily;
+import com.redhat.rhn.domain.channel.ChannelProduct;
+import com.redhat.rhn.domain.channel.ProductName;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.channel.test.ChannelFamilyFactoryTest;
 import com.redhat.rhn.domain.org.Org;
-import com.redhat.rhn.domain.product.test.SUSEProductTestUtils;
 import com.redhat.rhn.domain.role.RoleFactory;
-import com.redhat.rhn.taskomatic.task.ReportDBHelper;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.channel.software.ChannelSoftwareHandler;
+import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.testing.ChannelTestUtils;
+import com.redhat.rhn.testing.ErrataTestUtils;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.manager.hub.HubController;
 import com.suse.manager.model.hub.ChannelInfoJson;
+import com.suse.manager.model.hub.CustomChannelInfoJson;
 import com.suse.manager.model.hub.IssAccessToken;
 import com.suse.manager.model.hub.IssRole;
 import com.suse.manager.model.hub.ManagerInfoJson;
@@ -54,14 +57,16 @@ import com.suse.utils.Json;
 
 import com.google.gson.JsonObject;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,6 +82,8 @@ import spark.route.HttpMethod;
 public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
     private static final String DUMMY_SERVER_FQDN = "dummy-server.unit-test.local";
+
+    private final ControllerTestUtils testUtils = new ControllerTestUtils();
 
     private static final String TEST_ERROR_MESSAGE = "test error message";
 
@@ -94,41 +101,6 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         throw new NullPointerException(TEST_ERROR_MESSAGE);
     }
 
-    private String createTestUserName() {
-        return "testUser" + TestUtils.randomString();
-    }
-
-    private String createTestPassword() {
-        return "testPassword" + TestUtils.randomString();
-    }
-
-    private void createReportDbUser(String testReportDbUserName, String testReportDbPassword) {
-        String dbname = Config.get().getString(ConfigDefaults.REPORT_DB_NAME, "");
-        ConnectionManager localRcm = ConnectionManagerFactory.localReportingConnectionManager();
-        ReportDbHibernateFactory localRh = new ReportDbHibernateFactory(localRcm);
-        ReportDBHelper dbHelper = ReportDBHelper.INSTANCE;
-
-        dbHelper.createDBUser(localRh.getSession(), dbname, testReportDbUserName, testReportDbPassword);
-        localRcm.commitTransaction();
-    }
-
-    private boolean existsReportDbUser(String testReportDbUserName) {
-        ConnectionManager localRcm = ConnectionManagerFactory.localReportingConnectionManager();
-        ReportDbHibernateFactory localRh = new ReportDbHibernateFactory(localRcm);
-        ReportDBHelper dbHelper = ReportDBHelper.INSTANCE;
-
-        return dbHelper.hasDBUser(localRh.getSession(), testReportDbUserName);
-    }
-
-    private void cleanupReportDbUser(String testReportDbUserName) {
-        ConnectionManager localRcm = ConnectionManagerFactory.localReportingConnectionManager();
-        ReportDbHibernateFactory localRh = new ReportDbHibernateFactory(localRcm);
-        ReportDBHelper dbHelper = ReportDBHelper.INSTANCE;
-
-        dbHelper.dropDBUser(localRh.getSession(), testReportDbUserName);
-        localRcm.commitTransaction();
-    }
-
     private static Stream<Arguments> allApiEndpoints() {
         return Stream.of(Arguments.of(HttpMethod.post, "/hub/ping", null),
                 Arguments.of(HttpMethod.post, "/hub/sync/deregister", null),
@@ -141,7 +113,8 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
                 Arguments.of(HttpMethod.post, "/hub/removeReportDbCredentials", IssRole.HUB),
                 Arguments.of(HttpMethod.get, "/hub/listAllPeripheralOrgs", IssRole.PERIPHERAL),
                 Arguments.of(HttpMethod.get, "/hub/listAllPeripheralChannels", IssRole.PERIPHERAL),
-                Arguments.of(HttpMethod.post, "/hub/addVendorChannels", IssRole.PERIPHERAL)
+                Arguments.of(HttpMethod.post, "/hub/addVendorChannels", IssRole.PERIPHERAL),
+                Arguments.of(HttpMethod.post, "/hub/addCustomChannels", IssRole.PERIPHERAL)
         );
     }
 
@@ -164,10 +137,8 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     @ParameterizedTest
     @MethodSource("onlyGetApis")
     public void ensureGetApisNotWorkingWithPost(HttpMethod apiMethod, String apiEndpoint, IssRole apiRole) {
-        ControllerTestUtils utils = new ControllerTestUtils();
-
         assertThrows(IllegalStateException.class, () ->
-                        utils.withServerFqdn(DUMMY_SERVER_FQDN)
+                        testUtils.withServerFqdn(DUMMY_SERVER_FQDN)
                                 .withApiEndpoint(apiEndpoint)
                                 .withHttpMethod(HttpMethod.post)
                                 .withRole(apiRole)
@@ -179,10 +150,8 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     @ParameterizedTest
     @MethodSource("onlyPostApis")
     public void ensurePostApisNotWorkingWithGet(HttpMethod apiMethod, String apiEndpoint, IssRole apiRole) {
-        ControllerTestUtils utils = new ControllerTestUtils();
-
         assertThrows(IllegalStateException.class, () ->
-                        utils.withServerFqdn(DUMMY_SERVER_FQDN)
+                        testUtils.withServerFqdn(DUMMY_SERVER_FQDN)
                                 .withApiEndpoint(apiEndpoint)
                                 .withHttpMethod(HttpMethod.get)
                                 .withRole(apiRole)
@@ -195,9 +164,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     @MethodSource("onlyHubApis")
     public void ensureHubApisNotWorkingWithPeripheral(HttpMethod apiMethod, String apiEndpoint, IssRole apiRole)
             throws Exception {
-        ControllerTestUtils utils = new ControllerTestUtils();
-
-        String answerKO = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
+        String answerKO = (String) testUtils.withServerFqdn(DUMMY_SERVER_FQDN)
                 .withApiEndpoint(apiEndpoint)
                 .withHttpMethod(apiMethod)
                 .withRole(IssRole.PERIPHERAL)
@@ -213,9 +180,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     @MethodSource("onlyPeripheralApis")
     public void ensurePeripheralApisNotWorkingWithHub(HttpMethod apiMethod, String apiEndpoint, IssRole apiRole)
             throws Exception {
-        ControllerTestUtils utils = new ControllerTestUtils();
-
-        String answerKO = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
+        String answerKO = (String) testUtils.withServerFqdn(DUMMY_SERVER_FQDN)
                 .withApiEndpoint(apiEndpoint)
                 .withHttpMethod(apiMethod)
                 .withRole(IssRole.HUB)
@@ -231,16 +196,14 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     @MethodSource("allApiEndpoints")
     public void ensureNotWorkingWithoutToken(HttpMethod apiMethod, String apiEndpoint, IssRole apiRole)
             throws Exception {
-        ControllerTestUtils utils = new ControllerTestUtils();
-
         try {
-            utils.withServerFqdn(DUMMY_SERVER_FQDN)
+            testUtils.withServerFqdn(DUMMY_SERVER_FQDN)
                     .withApiEndpoint(apiEndpoint)
                     .withHttpMethod(apiMethod)
                     .withRole(apiRole)
                     .simulateControllerApiCall();
 
-            Assertions.fail(apiEndpoint + " API call should have failed without token");
+            fail(apiEndpoint + " API call should have failed without token");
         }
         catch (spark.HaltException ex) {
             assertEquals(HttpServletResponse.SC_BAD_REQUEST, ex.statusCode());
@@ -251,8 +214,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     public void checkPingApiEndpoint() throws Exception {
         String apiUnderTest = "/hub/ping";
 
-        ControllerTestUtils utils = new ControllerTestUtils();
-        String answer = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
+        String answer = (String) testUtils.withServerFqdn(DUMMY_SERVER_FQDN)
                 .withApiEndpoint(apiUnderTest)
                 .withHttpMethod(HttpMethod.post)
                 .withBearerTokenInHeaders()
@@ -271,8 +233,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         bodyMap.put("rootCA", "----- BEGIN TEST ROOTCA ----");
         bodyMap.put("token", dummyToken.getSerializedForm());
 
-        ControllerTestUtils utils = new ControllerTestUtils();
-        String answer = (String) utils.withServerFqdn(ConfigDefaults.get().getHostname())
+        String answer = (String) testUtils.withServerFqdn(ConfigDefaults.get().getHostname())
                 .withApiEndpoint(apiUnderTest)
                 .withHttpMethod(HttpMethod.post)
                 .withBearerTokenInHeaders()
@@ -290,14 +251,13 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     public void checkStoreCredentialsApiEndpoint() throws Exception {
         String apiUnderTest = "/hub/sync/storeCredentials";
 
-        String testUserName = createTestUserName();
-        String testPassword = createTestPassword();
+        String testUserName = testUtils.createTestUserName();
+        String testPassword = testUtils.createTestPassword();
         Map<String, String> bodyMap = new HashMap<>();
         bodyMap.put("username", testUserName);
         bodyMap.put("password", testPassword);
 
-        ControllerTestUtils utils = new ControllerTestUtils();
-        String answer = (String) utils.withServerFqdn(ConfigDefaults.get().getHostname())
+        String answer = (String) testUtils.withServerFqdn(ConfigDefaults.get().getHostname())
                 .withApiEndpoint(apiUnderTest)
                 .withHttpMethod(HttpMethod.post)
                 .withRole(IssRole.HUB)
@@ -313,8 +273,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     public void checkManagerinfoApiEndpoint() throws Exception {
         String apiUnderTest = "/hub/managerinfo";
 
-        ControllerTestUtils utils = new ControllerTestUtils();
-        String answer = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
+        String answer = (String) testUtils.withServerFqdn(DUMMY_SERVER_FQDN)
                 .withApiEndpoint(apiUnderTest)
                 .withHttpMethod(HttpMethod.get)
                 .withRole(IssRole.HUB)
@@ -333,17 +292,16 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     public void checkStoreReportDbCredentialsApiEndpoint() throws Exception {
         String apiUnderTest = "/hub/storeReportDbCredentials";
 
-        String testReportDbUserName = createTestUserName();
-        String testReportDbPassword = createTestPassword();
+        String testReportDbUserName = testUtils.createTestUserName();
+        String testReportDbPassword = testUtils.createTestPassword();
         Map<String, String> bodyMap = new HashMap<>();
         bodyMap.put("username", testReportDbUserName);
         bodyMap.put("password", testReportDbPassword);
 
         //check there is no user with that username
-        assertFalse(existsReportDbUser(testReportDbUserName));
+        assertFalse(testUtils.existsReportDbUser(testReportDbUserName));
 
-        ControllerTestUtils utils = new ControllerTestUtils();
-        String answer = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
+        String answer = (String) testUtils.withServerFqdn(DUMMY_SERVER_FQDN)
                 .withApiEndpoint(apiUnderTest)
                 .withHttpMethod(HttpMethod.post)
                 .withRole(IssRole.HUB)
@@ -355,12 +313,12 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         assertTrue(jsonObj.get("success").getAsBoolean(), apiUnderTest + " API call is failing");
 
         //check there is one user with that username
-        assertTrue(existsReportDbUser(testReportDbUserName),
+        assertTrue(testUtils.existsReportDbUser(testReportDbUserName),
                 apiUnderTest + " API reports no user " + testReportDbUserName);
 
         //cleanup
-        cleanupReportDbUser(testReportDbUserName);
-        assertFalse(existsReportDbUser(testReportDbUserName),
+        testUtils.cleanupReportDbUser(testReportDbUserName);
+        assertFalse(testUtils.existsReportDbUser(testReportDbUserName),
                 "cleanup of user not working for user " + testReportDbUserName);
     }
 
@@ -368,18 +326,17 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     public void checkRemoveReportDbCredentialsApiEndpoint() throws Exception {
         String apiUnderTest = "/hub/removeReportDbCredentials";
 
-        String testReportDbUserName = createTestUserName();
+        String testReportDbUserName = testUtils.createTestUserName();
         String testReportDbPassword = "testPassword" + TestUtils.randomString();
         Map<String, String> bodyMap = new HashMap<>();
         bodyMap.put("username", testReportDbUserName);
 
         //create a user
-        createReportDbUser(testReportDbUserName, testReportDbPassword);
-        assertTrue(existsReportDbUser(testReportDbUserName),
+        testUtils.createReportDbUser(testReportDbUserName, testReportDbPassword);
+        assertTrue(testUtils.existsReportDbUser(testReportDbUserName),
                 "failed creation of user " + testReportDbUserName);
 
-        ControllerTestUtils utils = new ControllerTestUtils();
-        String answer = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
+        String answer = (String) testUtils.withServerFqdn(DUMMY_SERVER_FQDN)
                 .withApiEndpoint(apiUnderTest)
                 .withHttpMethod(HttpMethod.post)
                 .withRole(IssRole.HUB)
@@ -390,7 +347,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
         assertTrue(jsonObj.get("success").getAsBoolean(), apiUnderTest + " API call is failing");
         //check the user is gone
-        assertFalse(existsReportDbUser(testReportDbUserName),
+        assertFalse(testUtils.existsReportDbUser(testReportDbUserName),
                 apiUnderTest + " API call fails to remove user " + testReportDbUserName);
     }
 
@@ -402,8 +359,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         Org org2 = UserTestUtils.findNewOrg("org2");
         Org org3 = UserTestUtils.findNewOrg("org3");
 
-        ControllerTestUtils utils = new ControllerTestUtils();
-        String answer = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
+        String answer = (String) testUtils.withServerFqdn(DUMMY_SERVER_FQDN)
                 .withApiEndpoint(apiUnderTest)
                 .withHttpMethod(HttpMethod.get)
                 .withRole(IssRole.PERIPHERAL)
@@ -431,8 +387,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         Channel testBaseChannel = ChannelTestUtils.createBaseChannel(user);
         Channel testChildChannel = ChannelTestUtils.createChildChannel(user, testBaseChannel);
 
-        ControllerTestUtils utils = new ControllerTestUtils();
-        String answer = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
+        String answer = (String) testUtils.withServerFqdn(DUMMY_SERVER_FQDN)
                 .withApiEndpoint(apiUnderTest)
                 .withHttpMethod(HttpMethod.get)
                 .withRole(IssRole.PERIPHERAL)
@@ -495,10 +450,12 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         return ChannelFactoryTest.createTestChannel(name, label, nullOrg, arch, cfam);
     }
 
-    private void utilityCreateVendorChannel(String name, String label, Channel vendorBaseChannel) throws Exception {
+    private Channel utilityCreateVendorChannel(String name, String label, Channel vendorBaseChannel) throws Exception {
         Channel vendorChannel = utilityCreateVendorBaseChannel(name, label);
         vendorChannel.setParentChannel(vendorBaseChannel);
+        vendorChannel.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha512"));
         ChannelFactory.save(vendorChannel);
+        return vendorChannel;
     }
 
     private static Stream<Arguments> allBaseAndVendorChannelAlreadyPresentCombinations() {
@@ -517,36 +474,23 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         //SUSE Linux Enterprise Server 11 SP3 x86_64
         String vendorBaseChannelTemplateName = "SLES11-SP3-Pool for x86_64";
         String vendorBaseChannelTemplateLabel = "sles11-sp3-pool-x86_64";
-
-        //SUSE Linux Enterprise Server 11 SP3 x86_64
         String vendorChannelTemplateName = "SLES11-SP3-Updates for x86_64";
         String vendorChannelTemplateLabel = "sles11-sp3-updates-x86_64";
 
-        SUSEProductTestUtils.createVendorSUSEProductEnvironment(user, null, true);
+        String answer = testUtils.createTestVendorChannels(user, DUMMY_SERVER_FQDN,
+                vendorBaseChannelTemplateName, vendorBaseChannelTemplateLabel,
+                baseChannelAlreadyPresentInPeripheral,
+                vendorChannelTemplateName, vendorChannelTemplateLabel,
+                channelAlreadyPresentInPeripheral);
 
         int expectedNumOfPeripheralCreatedChannels = 2;
-        Channel vendorBaseChannel = null;
         if (baseChannelAlreadyPresentInPeripheral) {
-            vendorBaseChannel = utilityCreateVendorBaseChannel(vendorBaseChannelTemplateName,
-                    vendorBaseChannelTemplateLabel);
             expectedNumOfPeripheralCreatedChannels--;
         }
         if (channelAlreadyPresentInPeripheral) {
-            utilityCreateVendorChannel(vendorChannelTemplateName, vendorChannelTemplateLabel, vendorBaseChannel);
             expectedNumOfPeripheralCreatedChannels--;
         }
 
-        Map<String, String> bodyMap = new HashMap<>();
-        bodyMap.put("vendorchannellabellist", Json.GSON.toJson(List.of(vendorChannelTemplateLabel)));
-
-        ControllerTestUtils utils = new ControllerTestUtils();
-        String answer = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
-                .withApiEndpoint(apiUnderTest)
-                .withHttpMethod(HttpMethod.post)
-                .withRole(IssRole.PERIPHERAL)
-                .withBearerTokenInHeaders()
-                .withBody(bodyMap)
-                .simulateControllerApiCall();
         List<ChannelInfoJson> peripheralVendorCreatedChannelsInfo =
                 Arrays.asList(Json.GSON.fromJson(answer, ChannelInfoJson[].class));
 
@@ -599,5 +543,299 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
                         testChildPeriphChInfo.get().getParentChannelId());
             }
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void checkApiAddCustomChannel(boolean testIncludeTestChannelInChain) throws Exception {
+        boolean testIsGpgCheck = true;
+        boolean testIssInstallerUpdates = true;
+        String testArchLabel = "channel-s390";
+        String testChecksumLabel = "sha256";
+
+        Date endOfLifeDate = testUtils.createDateUtil(2096, 10, 22);
+
+        User testPeripheralUser = UserTestUtils.findNewUser("peripheral_user_", "peripheral_org_", true);
+        Org testPeripheralOrg = testPeripheralUser.getOrg();
+        Long testPeripheralOrgId = testPeripheralOrg.getId();
+
+        // vendorBaseCh -> cloneBaseCh
+        //  ^                ^
+        // vendorCh -> cloneDevelCh -> cloneTestCh -> cloneProdCh
+
+        // prepare inputs
+        String vendorBaseChannelTemplateLabel = "sles11-sp3-pool-x86_64"; //SUSE Linux Enterprise Server 11 SP3 x86_64
+        String vendorChannelTemplateLabel = "sles11-sp3-updates-x86_64";
+
+        CustomChannelInfoJson cloneBaseChInfo = testUtils.createCustomChannelInfoJson(testPeripheralOrgId,
+                "cloneBaseCh", "", vendorBaseChannelTemplateLabel,
+                testIsGpgCheck, testIssInstallerUpdates, testArchLabel, testChecksumLabel, endOfLifeDate);
+
+        CustomChannelInfoJson cloneDevelChInfo = testUtils.createCustomChannelInfoJson(testPeripheralOrgId,
+                "cloneDevelCh", "cloneBaseCh", vendorChannelTemplateLabel,
+                testIsGpgCheck, testIssInstallerUpdates, testArchLabel, testChecksumLabel, endOfLifeDate);
+
+        CustomChannelInfoJson cloneTestChInfo = null;
+        String originalOfProdCh = "cloneDevelCh";
+        if (testIncludeTestChannelInChain) {
+            cloneTestChInfo = testUtils.createCustomChannelInfoJson(testPeripheralOrgId,
+                    "cloneTestCh", "", "cloneDevelCh",
+                    testIsGpgCheck, testIssInstallerUpdates, testArchLabel, testChecksumLabel, endOfLifeDate);
+            originalOfProdCh = "cloneTestCh";
+        }
+
+        CustomChannelInfoJson cloneProdChInfo = testUtils.createCustomChannelInfoJson(testPeripheralOrgId,
+                "cloneProdCh", "", originalOfProdCh,
+                testIsGpgCheck, testIssInstallerUpdates, testArchLabel, testChecksumLabel, endOfLifeDate);
+
+        testUtils.createTestVendorChannels(user, DUMMY_SERVER_FQDN);
+
+        Channel vendorBaseCh = ChannelFactory.lookupByLabel(vendorBaseChannelTemplateLabel);
+        assertNotNull(vendorBaseCh);
+        Channel vendorCh = ChannelFactory.lookupByLabel(vendorChannelTemplateLabel);
+        assertNotNull(vendorCh);
+
+        //create peripheral vendorCh custom cloned channels
+        List<CustomChannelInfoJson> customChannelInfoListIn = new ArrayList<>();
+        customChannelInfoListIn.add(cloneBaseChInfo);
+        customChannelInfoListIn.add(cloneDevelChInfo);
+        if (testIncludeTestChannelInChain) {
+            customChannelInfoListIn.add(cloneTestChInfo);
+        }
+        customChannelInfoListIn.add(cloneProdChInfo);
+
+        String answer = (String) testUtils.testAddCustomChannelsApiCall(DUMMY_SERVER_FQDN, customChannelInfoListIn);
+        List<ChannelInfoJson> peripheralCreatedCustomChInfo =
+                Arrays.asList(Json.GSON.fromJson(answer, ChannelInfoJson[].class));
+
+        if (testIncludeTestChannelInChain) {
+            assertEquals(4, peripheralCreatedCustomChInfo.size());
+        }
+        else {
+            assertEquals(3, peripheralCreatedCustomChInfo.size());
+        }
+        assertTrue(peripheralCreatedCustomChInfo.stream()
+                .anyMatch(e -> e.getLabel().equals("cloneBaseCh")));
+        assertTrue(peripheralCreatedCustomChInfo.stream()
+                .anyMatch(e -> e.getLabel().equals("cloneDevelCh")));
+        if (testIncludeTestChannelInChain) {
+            assertTrue(peripheralCreatedCustomChInfo.stream()
+                    .anyMatch(e -> e.getLabel().equals("cloneTestCh")));
+        }
+        assertTrue(peripheralCreatedCustomChInfo.stream()
+                .anyMatch(e -> e.getLabel().equals("cloneProdCh")));
+
+        Channel cloneBaseCh = ChannelFactory.lookupByLabel("cloneBaseCh");
+        assertNotNull(cloneBaseCh);
+        Channel cloneDevelCh = ChannelFactory.lookupByLabel("cloneDevelCh");
+        assertNotNull(cloneDevelCh);
+        Channel cloneTestCh = ChannelFactory.lookupByLabel("cloneTestCh");
+        if (testIncludeTestChannelInChain) {
+            assertNotNull(cloneTestCh);
+        }
+        Channel cloneProdCh = ChannelFactory.lookupByLabel("cloneProdCh");
+        assertNotNull(cloneProdCh);
+
+        // tests
+        // vendorBaseCh -> cloneBaseCh
+        //  ^                ^
+        // vendorCh -> cloneDevelCh -> cloneTestCh -> cloneProdCh
+
+        assertNull(vendorBaseCh.getParentChannel());
+        assertNull(cloneBaseCh.getParentChannel());
+        assertEquals(vendorBaseCh, vendorCh.getParentChannel());
+        assertEquals(cloneBaseCh, cloneDevelCh.getParentChannel());
+        if (testIncludeTestChannelInChain) {
+            assertNull(cloneTestCh.getParentChannel());
+        }
+        assertNull(cloneProdCh.getParentChannel());
+
+        assertTrue(vendorBaseCh.asCloned().isEmpty(), "vendorBaseCh should not be a cloned channel");
+        assertTrue(cloneBaseCh.asCloned().isPresent(), "cloneBaseCh should be a cloned channel");
+        assertTrue(vendorCh.asCloned().isEmpty(), "vendorCh should not be a cloned channel");
+        assertTrue(cloneDevelCh.asCloned().isPresent(), "cloneDevelCh should be a cloned channel");
+        if (testIncludeTestChannelInChain) {
+            assertTrue(cloneTestCh.asCloned().isPresent(), "cloneTestCh should be a cloned channel");
+        }
+        assertTrue(cloneProdCh.asCloned().isPresent(), "cloneProdCh should be a cloned channel");
+
+        assertEquals(vendorBaseCh, cloneBaseCh.asCloned().get().getOriginal());
+        assertEquals(vendorCh, cloneDevelCh.asCloned().get().getOriginal());
+        if (testIncludeTestChannelInChain) {
+            assertEquals(cloneDevelCh, cloneTestCh.asCloned().get().getOriginal());
+            assertEquals(cloneTestCh, cloneProdCh.asCloned().get().getOriginal());
+        }
+        else {
+            assertEquals(cloneDevelCh, cloneProdCh.asCloned().get().getOriginal());
+        }
+
+        ArrayList<Channel> channelsToTest = new ArrayList<>();
+        channelsToTest.add(cloneBaseCh);
+        channelsToTest.add(cloneDevelCh);
+        channelsToTest.add(cloneProdCh);
+        if (testIncludeTestChannelInChain) {
+            channelsToTest.add(cloneTestCh);
+        }
+        for (Channel ch : channelsToTest) {
+            testUtils.testCustomChannel(ch, testPeripheralOrgId,
+                    testIsGpgCheck,
+                    testIssInstallerUpdates,
+                    testArchLabel,
+                    testChecksumLabel,
+                    endOfLifeDate);
+        }
+    }
+
+    @Test
+    public void ensureNotThrowingWhenDataIsValid() throws Exception {
+        CustomChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
+
+        testUtils.checkAddCustomChannelsApiNotThrowing(DUMMY_SERVER_FQDN, List.of(customChInfo));
+    }
+
+    @Test
+    public void ensureThrowsWhenMissingPeriperhalOrg() throws Exception {
+        CustomChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
+        customChInfo.setPeripheralOrgId(75842L);
+
+        testUtils.checkAddCustomChannelsApiThrows(DUMMY_SERVER_FQDN, List.of(customChInfo), "No org id");
+    }
+
+    @Test
+    public void ensureThrowsWhenMissingChannelArch() throws Exception {
+        CustomChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
+        customChInfo.setChannelArchLabel("channel-dummy-arch");
+
+        testUtils.checkAddCustomChannelsApiThrows(DUMMY_SERVER_FQDN, List.of(customChInfo), "No channel arch");
+    }
+
+    @Test
+    public void ensureThrowsWhenMissingChecksumType() throws Exception {
+        CustomChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
+        customChInfo.setChecksumTypeLabel("sha123456");
+
+        testUtils.checkAddCustomChannelsApiThrows(DUMMY_SERVER_FQDN, List.of(customChInfo), "No checksum type");
+    }
+
+    @Test
+    public void ensureThrowsWhenMissingParentChannel() throws Exception {
+        CustomChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
+        customChInfo.setParentChannelLabel("missingParentChannelLabel");
+
+        testUtils.checkAddCustomChannelsApiThrows(DUMMY_SERVER_FQDN, List.of(customChInfo), "No parent channel");
+    }
+
+    @Test
+    public void ensureNotThrowingWhenParentChannelIsCreatedBefore() throws Exception {
+        CustomChannelInfoJson customParentChInfo = testUtils.createValidCustomChInfo("parentChannel");
+
+        CustomChannelInfoJson customChildChInfo = testUtils.createValidCustomChInfo("childChannel");
+        customChildChInfo.setParentChannelLabel("parentChannel");
+
+        testUtils.checkAddCustomChannelsApiNotThrowing(DUMMY_SERVER_FQDN,
+                Arrays.asList(customParentChInfo, customChildChInfo));
+    }
+
+    @Test
+    public void ensureThrowsWhenParentChannelIsCreatedAfter() throws Exception {
+        CustomChannelInfoJson customParentChInfo = testUtils.createValidCustomChInfo("parentChannel");
+
+        CustomChannelInfoJson customChildChInfo = testUtils.createValidCustomChInfo("childChannel");
+        customChildChInfo.setParentChannelLabel("parentChannel");
+
+        testUtils.checkAddCustomChannelsApiThrows(DUMMY_SERVER_FQDN,
+                Arrays.asList(customChildChInfo, customParentChInfo), "No parent channel");
+    }
+
+    @Test
+    public void ensureThrowsWhenMissingOriginalChannelInClonedChannels() throws Exception {
+        CustomChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
+
+        CustomChannelInfoJson clonedCustomChInfo = testUtils.createValidCustomChInfo("clonedCustomCh");
+        clonedCustomChInfo.setOriginalChannelLabel(customChInfo.getLabel() + "MISSING");
+
+        testUtils.checkAddCustomChannelsApiThrows(DUMMY_SERVER_FQDN,
+                Arrays.asList(customChInfo, clonedCustomChInfo), "No original channel");
+    }
+
+    @Test
+    public void ensureNotThrowingWhenOriginalChannelIsCreatedBefore() throws Exception {
+        CustomChannelInfoJson customChInfo = testUtils.createValidCustomChInfo("originalCustomCh");
+
+        CustomChannelInfoJson clonedCustomChInfo = testUtils.createValidCustomChInfo("clonedCustomCh");
+        clonedCustomChInfo.setOriginalChannelLabel("originalCustomCh");
+
+        testUtils.checkAddCustomChannelsApiNotThrowing(DUMMY_SERVER_FQDN,
+                Arrays.asList(customChInfo, clonedCustomChInfo));
+    }
+
+    @Test
+    public void ensureThrowsWhenOriginalChannelIsCreatedAfter() throws Exception {
+        CustomChannelInfoJson customChInfo = testUtils.createValidCustomChInfo("originalCustomCh");
+
+        CustomChannelInfoJson clonedCustomChInfo = testUtils.createValidCustomChInfo("clonedCustomCh");
+        clonedCustomChInfo.setOriginalChannelLabel("originalCustomCh");
+
+        testUtils.checkAddCustomChannelsApiThrows(DUMMY_SERVER_FQDN,
+                Arrays.asList(clonedCustomChInfo, customChInfo), "No original channel");
+    }
+
+    @Test
+    public void checkConversion() throws Exception {
+        User localUser = UserTestUtils.findNewUser("local_user_", "local_org_", true);
+        User peripheralUser = UserTestUtils.findNewUser("peripheral_user_", "peripheral_org_", true);
+        ChannelSoftwareHandler channelSoftwareHandler = new ChannelSoftwareHandler(null, null);
+        ProductName pn = ChannelFactoryTest.lookupOrCreateProductName(ChannelManager.RHEL_PRODUCT_NAME);
+        ChannelProduct cp = ErrataTestUtils.createTestChannelProduct();
+
+        //create vendor channels
+        String vendorBaseChannelTemplateName = "SLES11-SP3-Pool for x86_64";
+        String vendorBaseChannelTemplateLabel = "sles11-sp3-pool-x86_64";
+        Channel vendorBaseCh = testUtils.createVendorBaseChannel(vendorBaseChannelTemplateName,
+                vendorBaseChannelTemplateLabel);
+
+        String vendorChannelTemplateName = "SLES11-SP3-Updates for x86_64";
+        String vendorChannelTemplateLabel = "sles11-sp3-updates-x86_64";
+        Channel vendorCh = testUtils.createVendorChannel(vendorChannelTemplateName,
+                vendorChannelTemplateLabel, vendorBaseCh);
+        vendorCh.setProductName(pn);
+        vendorCh.setProduct(cp);
+        vendorCh.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha512"));
+
+        //test channel: clone of vendorChannel
+        int testChId = channelSoftwareHandler.clone(localUser, vendorCh.getLabel(), new HashMap<>(), true);
+        Channel testCh = ChannelFactory.lookupById((long) testChId);
+        testCh.setProduct(vendorCh.getProduct());
+
+        //production channel: clone of test channel
+        int productionChId = channelSoftwareHandler.clone(localUser, testCh.getLabel(), new HashMap<>(), true);
+        Channel productionCh = ChannelFactory.lookupById((long) productionChId);
+        productionCh.setProduct(testCh.getProduct());
+
+        CustomChannelInfoJson testChInfo = ChannelFactory.toCustomChannelInfo(testCh,
+                peripheralUser.getOrg().getId(), Optional.empty());
+
+        assertEquals(localUser.getOrg().getId(), testCh.getOrg().getId());
+        assertEquals(peripheralUser.getOrg().getId(), testChInfo.getPeripheralOrgId());
+        assertEquals("clone-of-sles11-sp3-updates-x86_64", testChInfo.getLabel());
+        assertNull(testChInfo.getParentChannelLabel());
+        assertEquals(ChannelManager.RHEL_PRODUCT_NAME, testChInfo.getProductNameLabel());
+        assertEquals(vendorCh.getProduct().getProduct(), testChInfo.getChannelProductProduct());
+        assertEquals(vendorCh.getProduct().getVersion(), testChInfo.getChannelProductVersion());
+        assertEquals("sha512", testChInfo.getChecksumTypeLabel());
+        assertEquals("sles11-sp3-updates-x86_64", testChInfo.getOriginalChannelLabel());
+
+        CustomChannelInfoJson productionChInfo = ChannelFactory.toCustomChannelInfo(productionCh,
+                peripheralUser.getOrg().getId(), Optional.empty());
+
+        assertEquals(localUser.getOrg().getId(), productionCh.getOrg().getId());
+        assertEquals(peripheralUser.getOrg().getId(), productionChInfo.getPeripheralOrgId());
+        assertEquals("clone-of-clone-of-sles11-sp3-updates-x86_64", productionChInfo.getLabel());
+        assertNull(productionChInfo.getParentChannelLabel());
+        assertEquals(ChannelManager.RHEL_PRODUCT_NAME, productionChInfo.getProductNameLabel());
+        assertEquals(vendorCh.getProduct().getProduct(), productionChInfo.getChannelProductProduct());
+        assertEquals(vendorCh.getProduct().getVersion(), productionChInfo.getChannelProductVersion());
+        assertEquals("sha512", productionChInfo.getChecksumTypeLabel());
+        assertEquals("clone-of-sles11-sp3-updates-x86_64", productionChInfo.getOriginalChannelLabel());
     }
 }

--- a/java/code/src/com/suse/manager/model/hub/CustomChannelInfoJson.java
+++ b/java/code/src/com/suse/manager/model/hub/CustomChannelInfoJson.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.model.hub;
+
+import com.suse.scc.model.SCCRepositoryJson;
+
+import java.util.Objects;
+
+public class CustomChannelInfoJson extends ModifyCustomChannelInfoJson {
+
+    private String parentChannelLabel;
+    private String channelArchLabel;
+    private String checksumTypeLabel;
+    private SCCRepositoryJson repositoryInfo;
+
+    /**
+     * Constructor
+     *
+     * @param labelIn The channel label
+     */
+    public CustomChannelInfoJson(String labelIn) {
+        super(labelIn);
+        repositoryInfo = new SCCRepositoryJson();
+    }
+
+    /**
+     * @return Returns the parentChannel.
+     */
+    public String getParentChannelLabel() {
+        return parentChannelLabel;
+    }
+
+    /**
+     * @param p The parentChannel to set.
+     */
+    public void setParentChannelLabel(String p) {
+        this.parentChannelLabel = p;
+    }
+
+    /**
+     * @return Returns the channelArch id
+     */
+    public String getChannelArchLabel() {
+        return channelArchLabel;
+    }
+
+    /**
+     * @param c The channelArch label to set.
+     */
+    public void setChannelArchLabel(String c) {
+        this.channelArchLabel = c;
+    }
+
+    /**
+     * @return Returns the checksum type label
+     */
+    public String getChecksumTypeLabel() {
+        return checksumTypeLabel;
+    }
+
+    /**
+     * @param checksumTypeLabelIn The checksum type label to set.
+     */
+    public void setChecksumTypeLabel(String checksumTypeLabelIn) {
+        this.checksumTypeLabel = checksumTypeLabelIn;
+    }
+
+    /**
+     * @return SCCRepositoryJson object with repository info
+     */
+    public SCCRepositoryJson getRepositoryInfo() {
+        return repositoryInfo;
+    }
+
+    /**
+     * @param repositoryInfoIn The SCCRepositoryJson object with repository info
+     */
+    public void setRepositoryInfo(SCCRepositoryJson repositoryInfoIn) {
+        repositoryInfo = repositoryInfoIn;
+    }
+
+    @Override
+    public boolean equals(Object oIn) {
+        if (oIn == null || getClass() != oIn.getClass()) {
+            return false;
+        }
+        if (!super.equals(oIn)) {
+            return false;
+        }
+        CustomChannelInfoJson that = (CustomChannelInfoJson) oIn;
+        return Objects.equals(getParentChannelLabel(), that.getParentChannelLabel()) &&
+                Objects.equals(getChannelArchLabel(), that.getChannelArchLabel()) &&
+                Objects.equals(getChecksumTypeLabel(), that.getChecksumTypeLabel()) &&
+                Objects.equals(getRepositoryInfo(), that.getRepositoryInfo());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getParentChannelLabel(), getChannelArchLabel(), getChecksumTypeLabel(),
+                getRepositoryInfo());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("CustomChannelInfoJson{");
+        sb.append(toStringCore());
+        sb.append("parentChannelLabel='").append(parentChannelLabel).append('\'');
+        sb.append(", channelArchLabel='").append(channelArchLabel).append('\'');
+        sb.append(", checksumTypeLabel='").append(checksumTypeLabel).append('\'');
+        sb.append(", repositoryInfo=").append(repositoryInfo);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/java/code/src/com/suse/manager/model/hub/ModifyCustomChannelInfoJson.java
+++ b/java/code/src/com/suse/manager/model/hub/ModifyCustomChannelInfoJson.java
@@ -59,7 +59,12 @@ public class ModifyCustomChannelInfoJson {
     }
 
     private Date longToDate(Long longIn) {
-        return new Date(longIn);
+        if (null == longIn) {
+            return new Date();
+        }
+        else {
+            return new Date(longIn);
+        }
     }
 
     private Long dateToLong(Date dateIn) {
@@ -178,14 +183,14 @@ public class ModifyCustomChannelInfoJson {
     /**
      * @return the GPGCheck
      */
-    public boolean isGpgCheck() {
+    public Boolean isGpgCheck() {
         return gpgCheck;
     }
 
     /**
      * @param gpgCheckIn the GPGCheck to set
      */
-    public void setGpgCheck(boolean gpgCheckIn) {
+    public void setGpgCheck(Boolean gpgCheckIn) {
         this.gpgCheck = gpgCheckIn;
     }
 
@@ -361,14 +366,14 @@ public class ModifyCustomChannelInfoJson {
     /**
      * @return Returns the installerUpdates.
      */
-    public boolean isInstallerUpdates() {
+    public Boolean isInstallerUpdates() {
         return installerUpdates;
     }
 
     /**
      * @param installerUpdatesIn The installerUpdates to set.
      */
-    public void setInstallerUpdates(boolean installerUpdatesIn) {
+    public void setInstallerUpdates(Boolean installerUpdatesIn) {
         installerUpdates = installerUpdatesIn;
     }
 

--- a/java/code/src/com/suse/manager/model/hub/ModifyCustomChannelInfoJson.java
+++ b/java/code/src/com/suse/manager/model/hub/ModifyCustomChannelInfoJson.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.model.hub;
+
+import com.redhat.rhn.domain.channel.Channel;
+
+import java.util.Date;
+import java.util.Objects;
+
+public class ModifyCustomChannelInfoJson {
+
+    private final String label;
+
+    private Long peripheralOrgId;
+    private String originalChannelLabel;
+
+    private String baseDir;
+    private String name;
+    private String summary;
+    private String description;
+    private String productNameLabel;
+    private Boolean gpgCheck;
+    private String gpgKeyUrl;
+    private String gpgKeyId;
+    private String gpgKeyFp;
+    private Long endOfLifeDate;
+
+    private String channelProductProduct;
+    private String channelProductVersion;
+    private String channelAccess;
+    private String maintainerName;
+    private String maintainerEmail;
+    private String maintainerPhone;
+    private String supportPolicy;
+    private String updateTag;
+    private Boolean installerUpdates;
+
+    /**
+     * Constructor
+     *
+     * @param labelIn The channel label
+     */
+    public ModifyCustomChannelInfoJson(String labelIn) {
+        label = labelIn;
+
+        gpgCheck = true;
+        channelAccess = Channel.PRIVATE;
+        installerUpdates = false;
+        originalChannelLabel = null;
+    }
+
+    private Date longToDate(Long longIn) {
+        return new Date(longIn);
+    }
+
+    private Long dateToLong(Date dateIn) {
+        if (null != dateIn) {
+            return dateIn.getTime();
+        }
+
+        return 0L;
+    }
+
+    /**
+     * @return Returns the label.
+     */
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * @return Returns the peripheral org id
+     */
+    public Long getPeripheralOrgId() {
+        return peripheralOrgId;
+    }
+
+    /**
+     * @param o The peripheral org id to set.
+     */
+    public void setPeripheralOrgId(Long o) {
+        this.peripheralOrgId = o;
+    }
+
+    /**
+     * @return Returns the original channel label if cloned.
+     */
+    public String getOriginalChannelLabel() {
+        return originalChannelLabel;
+    }
+
+    /**
+     * @param originalChannelLabelIn The he original channel label if cloned.
+     */
+    public void setOriginalChannelLabel(String originalChannelLabelIn) {
+        originalChannelLabel = originalChannelLabelIn;
+    }
+
+    /**
+     * @return Returns the baseDir.
+     */
+    public String getBaseDir() {
+        return baseDir;
+    }
+
+    /**
+     * @param b The baseDir to set.
+     */
+    public void setBaseDir(String b) {
+        this.baseDir = b;
+    }
+
+    /**
+     * @return Returns the name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param n The name to set.
+     */
+    public void setName(String n) {
+        this.name = n;
+    }
+
+    /**
+     * @return Returns the summary.
+     */
+    public String getSummary() {
+        return summary;
+    }
+
+    /**
+     * @param s The summary to set.
+     */
+    public void setSummary(String s) {
+        this.summary = s;
+    }
+
+    /**
+     * @return Returns the description.
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * @param d The description to set.
+     */
+    public void setDescription(String d) {
+        this.description = d;
+    }
+
+    /**
+     * @return the productName id
+     */
+    public String getProductNameLabel() {
+        return productNameLabel;
+    }
+
+    /**
+     * @param p the productName idto set
+     */
+    public void setProductNameLabel(String p) {
+        this.productNameLabel = p;
+    }
+
+    /**
+     * @return the GPGCheck
+     */
+    public boolean isGpgCheck() {
+        return gpgCheck;
+    }
+
+    /**
+     * @param gpgCheckIn the GPGCheck to set
+     */
+    public void setGpgCheck(boolean gpgCheckIn) {
+        this.gpgCheck = gpgCheckIn;
+    }
+
+    /**
+     * @return Returns the gPGKeyUrl.
+     */
+    public String getGpgKeyUrl() {
+        return gpgKeyUrl;
+    }
+
+    /**
+     * @param k The gPGKeyUrl to set.
+     */
+    public void setGpgKeyUrl(String k) {
+        gpgKeyUrl = k;
+    }
+
+    /**
+     * @return Returns the gPGKeyId.
+     */
+    public String getGpgKeyId() {
+        return gpgKeyId;
+    }
+
+    /**
+     * @param k The gPGKeyId to set.
+     */
+    public void setGpgKeyId(String k) {
+        gpgKeyId = k;
+    }
+
+    /**
+     * @return Returns the gPGKeyFp.
+     */
+    public String getGpgKeyFp() {
+        return gpgKeyFp;
+    }
+
+    /**
+     * @param k The gPGKeyFP to set.
+     */
+    public void setGpgKeyFp(String k) {
+        gpgKeyFp = k;
+    }
+
+
+    /**
+     * @return Returns the endOfLife.
+     */
+    public Date getEndOfLifeDate() {
+        return longToDate(endOfLifeDate);
+    }
+
+    /**
+     * @param endOfLifeDateIn The endOfLife to set.
+     */
+    public void setEndOfLifeDate(Date endOfLifeDateIn) {
+        this.endOfLifeDate = dateToLong(endOfLifeDateIn);
+    }
+
+    /**
+     * @return Returns the product name
+     */
+    public String getChannelProductProduct() {
+        return channelProductProduct;
+    }
+
+    /**
+     * @param channelProductProductIn The product name to set
+     */
+    public void setChannelProductProduct(String channelProductProductIn) {
+        this.channelProductProduct = channelProductProductIn;
+    }
+
+    /**
+     * @return Returns the product version
+     */
+    public String getChannelProductVersion() {
+        return channelProductVersion;
+    }
+
+    /**
+     * @param channelProductVersionIn The product version to set
+     */
+    public void setChannelProductVersion(String channelProductVersionIn) {
+        this.channelProductVersion = channelProductVersionIn;
+    }
+
+    /**
+     * @param acc public, protected, or private
+     */
+    public void setChannelAccess(String acc) {
+        channelAccess = acc;
+    }
+
+    /**
+     * @return public, protected, or private
+     */
+    public String getChannelAccess() {
+        return channelAccess;
+    }
+
+    /**
+     * @return maintainer's name
+     */
+    public String getMaintainerName() {
+        return maintainerName;
+    }
+
+    /**
+     * @param mname maintainer's name
+     */
+    public void setMaintainerName(String mname) {
+        maintainerName = mname;
+    }
+
+    /**
+     * @return maintainer's email
+     */
+    public String getMaintainerEmail() {
+        return maintainerEmail;
+    }
+
+    /**
+     * @param email maintainer's email
+     */
+    public void setMaintainerEmail(String email) {
+        maintainerEmail = email;
+    }
+
+    /**
+     * @return maintainer's phone number
+     */
+    public String getMaintainerPhone() {
+        return maintainerPhone;
+    }
+
+    /**
+     * @param phone maintainer's phone number (string)
+     */
+    public void setMaintainerPhone(String phone) {
+        maintainerPhone = phone;
+    }
+
+    /**
+     * @return channel's support policy
+     */
+    public String getSupportPolicy() {
+        return supportPolicy;
+    }
+
+    /**
+     * @param policy channel support policy
+     */
+    public void setSupportPolicy(String policy) {
+        supportPolicy = policy;
+    }
+
+    /**
+     * @return the updateTag
+     */
+    public String getUpdateTag() {
+        return updateTag;
+    }
+
+    /**
+     * @param updateTagIn the update tag
+     */
+    public void setUpdateTag(String updateTagIn) {
+        updateTag = updateTagIn;
+    }
+
+    /**
+     * @return Returns the installerUpdates.
+     */
+    public boolean isInstallerUpdates() {
+        return installerUpdates;
+    }
+
+    /**
+     * @param installerUpdatesIn The installerUpdates to set.
+     */
+    public void setInstallerUpdates(boolean installerUpdatesIn) {
+        installerUpdates = installerUpdatesIn;
+    }
+
+    @Override
+    public boolean equals(Object oIn) {
+        if (oIn == null || getClass() != oIn.getClass()) {
+            return false;
+        }
+        ModifyCustomChannelInfoJson that = (ModifyCustomChannelInfoJson) oIn;
+        return Objects.equals(getLabel(), that.getLabel()) &&
+                Objects.equals(getPeripheralOrgId(), that.getPeripheralOrgId()) &&
+                Objects.equals(getOriginalChannelLabel(), that.getOriginalChannelLabel()) &&
+                Objects.equals(getBaseDir(), that.getBaseDir()) &&
+                Objects.equals(getName(), that.getName()) &&
+                Objects.equals(getSummary(), that.getSummary()) &&
+                Objects.equals(getDescription(), that.getDescription()) &&
+                Objects.equals(getProductNameLabel(), that.getProductNameLabel()) &&
+                Objects.equals(isGpgCheck(), that.isGpgCheck()) &&
+                Objects.equals(getGpgKeyUrl(), that.getGpgKeyUrl()) &&
+                Objects.equals(getGpgKeyId(), that.getGpgKeyId()) &&
+                Objects.equals(getGpgKeyFp(), that.getGpgKeyFp()) &&
+                Objects.equals(getEndOfLifeDate(), that.getEndOfLifeDate()) &&
+                Objects.equals(getChannelProductProduct(), that.getChannelProductProduct()) &&
+                Objects.equals(getChannelProductVersion(), that.getChannelProductVersion()) &&
+                Objects.equals(getChannelAccess(), that.getChannelAccess()) &&
+                Objects.equals(getMaintainerName(), that.getMaintainerName()) &&
+                Objects.equals(getMaintainerEmail(), that.getMaintainerEmail()) &&
+                Objects.equals(getMaintainerPhone(), that.getMaintainerPhone()) &&
+                Objects.equals(getSupportPolicy(), that.getSupportPolicy()) &&
+                Objects.equals(getUpdateTag(), that.getUpdateTag()) &&
+                Objects.equals(isInstallerUpdates(), that.isInstallerUpdates());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getLabel(), getPeripheralOrgId(), getOriginalChannelLabel(), getBaseDir(), getName(),
+                getSummary(), getDescription(), getProductNameLabel(), isGpgCheck(), getGpgKeyUrl(), getGpgKeyId(),
+                getGpgKeyFp(), getEndOfLifeDate(), getChannelProductProduct(), getChannelProductVersion(),
+                getChannelAccess(), getMaintainerName(), getMaintainerEmail(), getMaintainerPhone(),
+                getSupportPolicy(), getUpdateTag(), isInstallerUpdates());
+    }
+
+    protected String toStringCore() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("label='").append(label).append('\'');
+        sb.append(", peripheralOrgId=").append(peripheralOrgId);
+        sb.append(", originalChannelLabel='").append(originalChannelLabel).append('\'');
+        sb.append(", baseDir='").append(baseDir).append('\'');
+        sb.append(", name='").append(name).append('\'');
+        sb.append(", summary='").append(summary).append('\'');
+        sb.append(", description='").append(description).append('\'');
+        sb.append(", productNameLabel='").append(productNameLabel).append('\'');
+        sb.append(", gpgCheck=").append(gpgCheck);
+        sb.append(", gpgKeyUrl='").append(gpgKeyUrl).append('\'');
+        sb.append(", gpgKeyId='").append(gpgKeyId).append('\'');
+        sb.append(", gpgKeyFp='").append(gpgKeyFp).append('\'');
+        sb.append(", endOfLifeDate=").append(endOfLifeDate);
+        sb.append(", channelProductProduct='").append(channelProductProduct).append('\'');
+        sb.append(", channelProductVersion='").append(channelProductVersion).append('\'');
+        sb.append(", channelAccess='").append(channelAccess).append('\'');
+        sb.append(", maintainerName='").append(maintainerName).append('\'');
+        sb.append(", maintainerEmail='").append(maintainerEmail).append('\'');
+        sb.append(", maintainerPhone='").append(maintainerPhone).append('\'');
+        sb.append(", supportPolicy='").append(supportPolicy).append('\'');
+        sb.append(", updateTag='").append(updateTag).append('\'');
+        sb.append(", installerUpdates=").append(installerUpdates);
+        return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ModifyCustomChannelInfoJson{");
+        sb.append(toStringCore());
+        sb.append('}');
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## What does this PR change?
I added an API endpoint to modifycustom channels in the peripheral server.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25353
Port(s):
- [x] **DONE**

## Changelogs
- [x] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge
